### PR TITLE
Change nVidia to NVIDIA

### DIFF
--- a/_articles/encryption-bug.md
+++ b/_articles/encryption-bug.md
@@ -2,20 +2,20 @@
 layout: article
 title: Problems Entering Password with Full Disk Encryption
 description: >
-  If you have a system with full disk encryption and an nVidia graphics card, there is a bug in Plymouth that prevents the password from showing or being accepted.  Here are some solutions to this problem.
+  If you have a system with full disk encryption and an NVIDIA graphics card, there is a bug in Plymouth that prevents the password from showing or being accepted.  Here are some solutions to this problem.
 keywords:
   - System76
   - encryption
   - full disk encryption
   - password
-  - nVidia
+  - NVIDIA
   - Plymouth
 hidden: false
 section: solutions
 
 ---
 
-There is a bug in the Plymouth splash screen which can cause issues inputting your password.  This only affects systems with nVidia hardware.
+There is a bug in the Plymouth splash screen which can cause issues inputting your password.  This only affects systems with NVIDIA hardware.
 
 The current work-around is to disable the splash screen while booting.  To disable the splash screen on the first boot, tap <kbd>ESC</kbd> while booting to enter the GRUB menu.  Press <kbd>E</kbd> to edit the default option, then delete the word 'splash' from the second to last line, and press <kbd>F10</kbd> to continue booting.  Once booted, disable the Plymouth splash screen permanently by editing the GRUB configuration file with this command:
 

--- a/_articles/upgrade.md
+++ b/_articles/upgrade.md
@@ -144,7 +144,7 @@ Once you've upgraded Ubuntu, you'll need to download and install the System76 Dr
 
 ---
 
-**For NVIDIA Graphics:** If you ordered a system with a discrete nVidia graphics card, you will need to manually install the closed source drivers for your card to get the optimum performance. Open the Terminal app and enter the following command:
+**For NVIDIA Graphics:** If you ordered a system with a discrete NVIDIA graphics card, you will need to manually install the closed source drivers for your card to get the optimum performance. Open the Terminal app and enter the following command:
 
     sudo apt install system76-driver-nvidia
 

--- a/_articles/windows-drivers.md
+++ b/_articles/windows-drivers.md
@@ -16,9 +16,9 @@ Most of the hardware in a System76 computer is Intel based, and the Windows Upda
 
 [Intel Driver Update Utility](http://www.intel.com/content/www/us/en/support/detect.html)
 
-For systems with nVidia graphics cards, nVidia drivers can be found on thier website:
+For systems with NVIDIA graphics cards, NVIDIA drivers can be found on thier website:
 
-[nVidia Drivers](http://www.nvidia.com/Download/index.aspx)
+[NVIDIA Drivers](http://www.nvidia.com/Download/index.aspx)
 
 Trackpad drivers for our laptops can be found on Synaptic's website:
 


### PR DESCRIPTION
Their official branding is `NVIDIA` and that's how it is used across all of system76.com