### PR TITLE
Change "Mint Linux" to "Linux Mint"

### DIFF
--- a/_articles/desktop-environment.md
+++ b/_articles/desktop-environment.md
@@ -50,7 +50,7 @@ sudo apt install mate-desktop-environment-extras mate-dock-applet
 
 ### Cinnamon
 
-Cinnamon is used in Mint Linux by default. Cinnamon strives to provide a traditional experience and is a fork of GNOME 3.
+Cinnamon is used in Linux Mint by default. Cinnamon strives to provide a traditional experience and is a fork of GNOME 3.
 
 ![Cinnamon](/images/desktop-environment/Cinnamon.png)
 


### PR DESCRIPTION
This changes the name "Mint Linux" to the (correct) "Linux Mint" (see [discussion on the Linux Mint forum](https://forums.linuxmint.com/viewtopic.php?f=60&p=1376867#p1376867)).
Cheers!