### PR TITLE
include pepperflashplugin-nonfree on install

### DIFF
--- a/_articles/flash.md
+++ b/_articles/flash.md
@@ -28,7 +28,8 @@ section: articles
 To watch Flash videos with <u>Firefox</u>, <u>Chromium</u>, and <u>Opera</u>, we recommend using <u>Pepperflash</u>, rather than <u>Adobe Flash</u>, for security reasons.  <u>Pepperflash</u> is maintained by Google and included in the <u>Chrome</u> browser by default, and can be downloaded separately to be used in other browsers.  Please run this command to install <u>Pepperflash</u>:
 
 ```
-sudo apt install browser-plugin-freshplayer-pepperflash
+sudo apt install browser-plugin-freshplayer-pepperflash pepperflashplugin-nonfree
+
 ```
 
 Otherwise, to install <u>Google Chrome</u>, follow these instructions:


### PR DESCRIPTION
I run chromium on pop os and couldn't view a flash video. I tried installing browser-plugin-freshplayer-pepperflash on it's own and it didn't do anything. Installing the additional non free plugin seemed to do the trick. The advise at 
https://askubuntu.com/questions/836261/pepperflashplugin-nonfree-package-installation-fails-since-chrome-54-is-out-oct
is to not use this package at all and instead use adobe-flashplugin. I've got it working for now so will trade the resultant vulnerabilities for having it work. However, once I'm out of exam season, I'll revisit. 
Simon