### PR TITLE
Fix typo in Ubuntu cuda install instructions

### DIFF
--- a/_articles/cuda.md
+++ b/_articles/cuda.md
@@ -79,7 +79,7 @@ cat /usr/lib/cuda/version.txt
 The previous instructions will work with Pop!_OS out of the box but for Ubuntu and other Debian derivatives the following commands will need to be ran first:
 
 ```
-sudo echo "deb http://apt.pop-os.org/proprietary bionic/main" | sudo tee -a /etc/apt/source.list
+sudo echo "deb [arch=amd64] http://apt.pop-os.org/proprietary bionic main" | sudo tee -a /etc/apt/sources.list
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 204DD8AEC33A7AFF
 sudo apt update
 ```


### PR DESCRIPTION
- Append apt source entry to `sources.list`, not `source.list`
- Remove `/` between bionic and main, because apt complains
- Specify `arch=amd64`; not sure if that'll work for everyone, but was necessary for me on a 2018 Bonobo

Unrelated question: should the `apt.pop-os.org` domain be served over HTTPS?