### PR TITLE
fix(upgrade): add note about `pop-desktop` missing dep

### DIFF
--- a/_articles/upgrade-pop.md
+++ b/_articles/upgrade-pop.md
@@ -49,6 +49,12 @@ Before beginning the upgrade, it is important to ensure that the `pop-desktop` m
 sudo apt install pop-desktop
 ```
 
+If you receive a notice that you have an unmet dependency for `sessioninstaller`, you'll need to install that before you can successfully install the `pop-desktop` package.
+
+```
+sudo apt install sessioninstaller
+```
+
 Now to change from LTS to Non-LTS release with this command:
 
 ```


### PR DESCRIPTION
Hello! I considered doing this as an issue, but this seemed easy enough. I'm going through the release upgrade process, and I ran into an unmet dep for `pop-desktop`. It's a simple fix to install the missing package, but this might be something you want your package to include when it is installed (I don't really know how apt packages trigger sub-dep installs).

So far this is the only deviation I've encountered from the upgrade docs. Thank you!