### PR TITLE
Create numba.md

### DIFF
--- a/_articles/numba.md
+++ b/_articles/numba.md
@@ -1,0 +1,58 @@
+---
+layout: article
+title: Install Numba  on Python3
+description: >
+  Complete instructions on setting up the Numba library in Python for fast, parralell computing using the NVIDIA CUDA toolkit.
+keywords:
+  - PYTHON
+  - NUMBA
+  - NVIDIA
+  - CUDA
+image: http://support.system76.com/images/system76.png
+hidden: false
+section: software-applications
+
+---
+
+## Install on Pop!_OS
+
+### Prerequisits
+
+These instructions assume that the CUDA toolkit is already set up and working on your installation of Pop_OS.
+The Environmental Variable setup assumes the default Bash shell is used in your environment. Should you be using a different one, please set up the environmental variables using that (eg. for zsh, ~/.zshrc).
+
+### Install The latest Numba library
+
+To install Numba, please run this command:
+
+```
+sudo apt install python3-numba
+```
+
+### Environmental Variable setup
+
+In ~/.bashrc, please add:
+
+```
+# path to CUDA driver shared library file.
+export NUMBAPRO_CUDA_DRIVER=/usr/lib/x86_64-linux-gnu/libcuda.so
+# path to CUDA libNVVM shared library file
+export NUMBAPRO_NVVM=/usr/lib/cuda/nvvm/lib64/libnvvm.so
+# path to CUDA libNVVM libdevice directory which contains .bc files.
+export NUMBAPRO_LIBDEVICE=/usr/lib/cuda/nvvm/libdevice
+```
+Finally, restart your computer to complete setup. 
+
+### Test installation
+
+To test your new Numba installation, from the commandline type:
+
+```
+numba -s
+```
+Details of the installation should be returned.
+
+### Further information
+
+For further details on Numba, please see:
+http://numba.pydata.org/

--- a/_articles/numba.md
+++ b/_articles/numba.md
@@ -40,6 +40,8 @@ export NUMBAPRO_CUDA_DRIVER=/usr/lib/x86_64-linux-gnu/libcuda.so
 export NUMBAPRO_NVVM=/usr/lib/cuda/nvvm/lib64/libnvvm.so
 # path to CUDA libNVVM libdevice directory which contains .bc files.
 export NUMBAPRO_LIBDEVICE=/usr/lib/cuda/nvvm/libdevice
+# path to CUDA libraries
+export NUMBAPRO_CUDALIB=/usr/lib/cuda/lib64
 ```
 Finally, restart your computer to complete setup. 
 

--- a/_articles/numba.md
+++ b/_articles/numba.md
@@ -10,7 +10,7 @@ keywords:
   - CUDA
 image: http://support.system76.com/images/system76.png
 hidden: false
-section: software-applications
+section: community
 
 ---
 
@@ -19,7 +19,6 @@ section: software-applications
 ### Prerequisits
 
 These instructions assume that the CUDA toolkit is already set up and working on your installation of Pop_OS.
-The Environmental Variable setup assumes the default Bash shell is used in your environment. Should you be using a different one, please set up the environmental variables using that (eg. for zsh, ~/.zshrc).
 
 ### Install The latest Numba library
 
@@ -30,8 +29,9 @@ sudo apt install python3-numba
 ```
 
 ### Environmental Variable setup
-
-In ~/.bashrc, please add:
+To make changes on the system level, add the below in  /etc/environment .
+To make changes on user level (assuming you have the default bash shell), add in ~/.bashrc.
+Note the system level approach is not dependendent on your choice of shell. 
 
 ```
 # path to CUDA driver shared library file.


### PR DESCRIPTION
This file provides instructions on setting up Numba to work with a System76 computer running Pop_OS. It follows my efforts to install the library with the help of the System76 team and the Numba support team. The key difficulty was getting the right address for NUMBAPRO_CUDA_DRIVER.

Further detail is here:
https://github.com/numba/numba/issues/3963
