### PR TITLE
Update cuda.md

### DIFF
--- a/_articles/cuda.md
+++ b/_articles/cuda.md
@@ -25,7 +25,7 @@ sudo apt install system76-cuda-latest
 To install the cuDNN library, please run this command:
 
 ```
-sudo apt install system76-cudnn-10.0
+sudo apt install system76-cudnn-10.1
 ```
 
 ### For older releases of The NVIDIA CUDA Toolkit


### PR DESCRIPTION
I didn't see a `system76-cudnn-latest`, but this should now be version `10.1` instead of `10.0` otherwise if you run the first command (`sudo apt install system76-cuda-latest`, which currently installs cuda 10.1) then when you run `sudo apt install system76-cudnn-10.0` it additionally installs the whole cuda 10.0 (after you just installed 10.1).