### PR TITLE
Update cuDNN package version

### DIFF
--- a/_articles/cuda.md
+++ b/_articles/cuda.md
@@ -39,7 +39,7 @@ sudo apt install system76-cuda-10.0
 For the respective cuDNN library:
 
 ```
-sudo apt install system76-cudnn-10.1
+sudo apt install system76-cudnn-10.0
 ```
 
 To install CUDA 9.2:

--- a/_articles/cuda.md
+++ b/_articles/cuda.md
@@ -25,10 +25,22 @@ sudo apt install system76-cuda-latest
 To install the cuDNN library, please run this command:
 
 ```
-sudo apt install system76-cudnn-10.0
+sudo apt install system76-cudnn-10.1
 ```
 
 ### For older releases of The NVIDIA CUDA Toolkit
+
+To install CUDA 10.0:
+
+```
+sudo apt install system76-cuda-10.0
+```
+
+For the respective cuDNN library:
+
+```
+sudo apt install system76-cudnn-10.1
+```
 
 To install CUDA 9.2:
 


### PR DESCRIPTION
I saw that @ericphanson closed their pull request due to inactivity: https://github.com/system76/docs/pull/161

I don't know why we don't have `system76-cudnn-latest` to match `system76-cuda-latest`, but the "latest" section of our article should give the latest version. This PR updates the latest package name to 10.1, and adds 10.0 to the list of older versions.