### PR TITLE
Correct BIOS key for Meerkat.

### DIFF
--- a/_articles/boot-menu.md
+++ b/_articles/boot-menu.md
@@ -16,4 +16,6 @@ section: hardware-drivers
 
 To enter BIOS for recent System76 laptops, hold the <kbd>F2</kbd> key immediately after turning your computer on.  For the boot menu, hold down the <kbd>F7</kbd> key.  For older laptops, hold the <kbd>F1</kbd> key.
 
-To enter BIOS for desktops, hold down the <kbd>DEL</kbd> key.  To show the boot menu (besides the Meerkat), hold the <kbd>F8</kbd> or <kbd>F12</kbd> key. For the Meerkat, hold the <kbd>F10</kbd> key.
+To enter BIOS for desktops (besides the Meerkat), hold down the <kbd>DEL</kbd> key.  To show the boot menu (besides the Meerkat), hold the <kbd>F8</kbd> or <kbd>F12</kbd> key. 
+
+For the Meerkat, hold the <kbd>F2</kbd> key for the BIOS, or the <kbd>F10</kbd> key for the boot menu.

--- a/_articles/boot-menu.md
+++ b/_articles/boot-menu.md
@@ -16,6 +16,6 @@ section: hardware-drivers
 
 To enter BIOS for recent System76 laptops, hold the <kbd>F2</kbd> key immediately after turning your computer on.  For the boot menu, hold down the <kbd>F7</kbd> key.  For older laptops, hold the <kbd>F1</kbd> key.
 
-To enter BIOS for desktops (besides the Meerkat), hold down the <kbd>DEL</kbd> key.  To show the boot menu (besides the Meerkat), hold the <kbd>F8</kbd> or <kbd>F12</kbd> key. 
+To enter BIOS for desktops (besides the Meerkat), hold down the <kbd>DEL</kbd> key.  To show the boot menu, hold the <kbd>F8</kbd> or <kbd>F12</kbd> key. 
 
 For the Meerkat, hold the <kbd>F2</kbd> key for the BIOS, or the <kbd>F10</kbd> key for the boot menu.


### PR DESCRIPTION
The article for accessing the BIOS or Boot Menu currently specifies that the Meerkat has a different boot menu key than other desktops, but it fails to mention that the BIOS key is also different.

(I confirmed with Aaron that the Meerkat in our lab, which has F2 as its BIOS key, is using production firmware.)