### PR TITLE
Update link for latest Ubuntu version

### DIFF
--- a/_articles/live-disk.md
+++ b/_articles/live-disk.md
@@ -32,7 +32,7 @@ A live disk is a handy tool to have around!
 
 ### For Ubuntu/Pop!_OS
 
-In order to install Pop!_OS or Ubuntu, we must first download the .iso image, this is a disk image with the operating system and installer on it. You can [download Pop!_OS here](http://pop.system76.com), [Ubuntu 18.04 here](https://www.ubuntu.com/download/desktop/thank-you?version=18.04.3&architecture=amd64) and [Ubuntu 19.04 here](http://releases.ubuntu.com/19.04/ubuntu-19.04-desktop-amd64.iso?_ga=2.48640864.771476182.1557254381-376903203.1554504705) just click the link and the download should begin!
+In order to install Pop!_OS or Ubuntu, we must first download the .iso image, this is a disk image with the operating system and installer on it. You can [download Pop!_OS here](http://pop.system76.com), [Ubuntu 18.04 here](https://www.ubuntu.com/download/desktop/thank-you?version=18.04.3&architecture=amd64), or [Ubuntu 19.10 here](https://ubuntu.com/download/desktop/thank-you/?version=19.10&architecture=amd64).
 
 In order to make a live disk of Pop!_OS you must have a bootable flash drive. You'll need a flash drive, of course, and software to write the Pop!_OS .iso image to the drive. There's a variety of applications you can use to write disk images to a flash drive, but for this tutorial we'll use the Disks applicaton for Ubuntu and Etcher for Windows/MacOS.
 

--- a/_articles/live-disk.md
+++ b/_articles/live-disk.md
@@ -32,7 +32,7 @@ A live disk is a handy tool to have around!
 
 ### For Ubuntu/Pop!_OS
 
-In order to install Pop!_OS or Ubuntu, we must first download the .iso image, this is a disk image with the operating system and installer on it. You can [download Pop!_OS here](http://pop.system76.com), [Ubuntu 18.04 here](https://www.ubuntu.com/download/desktop/thank-you?version=18.04.3&architecture=amd64), or [Ubuntu 19.10 here](https://ubuntu.com/download/desktop/thank-you/?version=19.10&architecture=amd64).
+In order to install Pop!_OS or Ubuntu, we must first download the .iso image. This is a disk image with the operating system and installer on it. You can [download Pop!_OS here](http://pop.system76.com), [Ubuntu 18.04 here](https://www.ubuntu.com/download/desktop/thank-you?version=18.04.3&architecture=amd64), or [Ubuntu 19.10 here](https://ubuntu.com/download/desktop/thank-you/?version=19.10&architecture=amd64).
 
 In order to make a live disk of Pop!_OS you must have a bootable flash drive. You'll need a flash drive, of course, and software to write the Pop!_OS .iso image to the drive. There's a variety of applications you can use to write disk images to a flash drive, but for this tutorial we'll use the Disks applicaton for Ubuntu and Etcher for Windows/MacOS.
 


### PR DESCRIPTION
This change updates the link for the latest version of Ubuntu from 19.04 to 19.10 in the live disk article.

It also removes the unnecessary sentence "just click the link and the download should begin!" because all three of the links point to a download page (not directly to a file.)

Finally, it fixes a run-on sentence earlier in the paragraph.