### PR TITLE
Update docking station page to reflect my experience with the HP G2 Dock on the Galago Pro

### DIFF
--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -27,8 +27,8 @@ We have tested the following docks:
 ### Community-tested docks:
 
 Community members have reported that the following docks work with our products:
- - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [community-tested on an Intel system](https://github.com/system76/docs/pull/206) (**)
- - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [community-tested on an Intel system](https://github.com/system76/docs/pull/231)
+ - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/206) on an Intel system] (**)
+ - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [[community-tested](https://github.com/system76/docs/pull/231) on an Intel system]
 
 ### For Intel systems
 

--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -28,7 +28,7 @@ We have tested the following docks:
 
 Community members have reported that the following docks work with our products:
  - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [Community-tested on an Intel system] (**)
- - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [Community-tested on a galp4 Galago Pro (2019 model). Drives two 27" 1920x1080 DisplayPort monitors, charging, ethernet, and 3 USB connections simultaneously through the single Thunderbolt port on the Galago Pro.] (**)
+ - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [Community-tested on a galp4 Galago Pro (2019 model). Drives two 27" 1920x1080 DisplayPort monitors, charging, ethernet, and 3 USB connections simultaneously through the single Thunderbolt port on the Galago Pro.]
 
 ### For Intel systems
 

--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -27,8 +27,8 @@ We have tested the following docks:
 ### Community-tested docks:
 
 Community members have reported that the following docks work with our products:
- - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [Community-tested on an Intel system] (**)
- - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [Community-tested on a galp4 Galago Pro (2019 model). Drives two 27" 1920x1080 DisplayPort monitors, charging, ethernet, and 3 USB connections simultaneously through the single Thunderbolt port on the Galago Pro.]
+ - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [community-tested on an Intel system](https://github.com/system76/docs/pull/206) (**)
+ - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [community-tested on an Intel system](https://github.com/system76/docs/pull/231)
 
 ### For Intel systems
 

--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -16,7 +16,7 @@ section: accessories
 
 ### Compatible Intel systems
 
- - Galago Pro (galp3-b, galp3-c)
+ - Galago Pro (galp4, galp3-b, galp3-c)
  - Darter Pro (darp5)
 
 ### System76-tested docks:
@@ -27,7 +27,8 @@ We have tested the following docks:
 ### Community-tested docks:
 
 Community members have reported that the following docks work with our products:
- - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [community-tested on an Intel system] (**)
+ - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [Community-tested on an Intel system] (**)
+ - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [Community-tested on a galp4 Galago Pro (2019 model). Drives two 27" 1920x1080 DisplayPort monitors, charging, ethernet, and 3 USB connections simultaneously through the single Thunderbolt port on the Galago Pro.] (**)
 
 ### For Intel systems
 


### PR DESCRIPTION
Just received my Galago Pro on Wednesday. I successfully connected it both at home and at work to my HP G2 Thunderbolt Docks with 2 1080p monitors, 3 usb ports, and ethernet. All I had to do was authorize the docks in the Pop OS Thunderbolt menu. I assume it relies on the dkms driver but that was already installed. Worked much more seamlessly than I anticipated. I'm extremely pleased.

Issues:


- ~~Occasionally gets finnicky and won't recognize the attached monitors especially when resuming from suspend with the Thunderbolt port plugged in. I tend to just unplug the thunderbolt port when suspending and plug it back in after I've resumed from suspend.~~
- Seemed to have trouble driving more than 3 USB ports. When I added a daisy chained a USB hub & tried to drive my cooling pad's fan in addition to the above devices it would no longer drive the monitors.
- ~~Can't wake the laptop from suspend with the lid closed. I have to open the lid, wake the laptop, and then the monitors are recognized properly. However, once the monitors are connected it works fine. Any ideas for fixing that would be appreciated (I assume there's some linux system setting that would allow me to unsuspend with the lid closed. I'll probably investigate this eventually)~~

Still, driving multiple monitors, using USB devices, and charging from a single port is more than I expected since I've had bad luck with these Thunderbolt docks in the past. 

Edit: The two issues I crossed out were fixed simply by enabling the wakeup flag on my USB devices, e.g. for all USB devices `echo enabled|sudo tee /sys/bus/usb/devices/*/power/wakeup`