### PR TITLE
Add command to remove bad backport-iwlwifi-dkms package

### DIFF
--- a/_articles/wireless.md
+++ b/_articles/wireless.md
@@ -38,6 +38,12 @@ Some router settings can cause problems. Try adjusting your access point to thes
 - Lower the max/burst speeds, turn off channel bonding, and reduce channel width. Setting the speed to 600 Mb/s or 450 Mb/s will use spread frequencies to achieve those speeds and may decrease stability. Try setting it to 289/300 Mb/s (N speed) or or 54 Mb/s (G speed).
 - After making these changes, reboot the router.
 
+If the issues started after you applied updates, try running this command to make sure a bad WiFi driver has not been installed, then reboot your computer:
+
+```
+sudo apt remove backport-iwlwifi-dkms
+```
+
 ### Advanced Troubleshooting
 
 If the above steps aren't working, or you would like to fine tune and improve you connection, see the following steps.


### PR DESCRIPTION
A little late, but this adds a step to the WiFi troubleshooting page to remove the backport-iwlwifi-dkms package, since we've had a significant volume of support tickets solved by taking that step.