### PR TITLE
Update login loop page

### DIFF
--- a/_articles/login-loop.md
+++ b/_articles/login-loop.md
@@ -30,19 +30,19 @@ Each cause has a different solution, and certain items (such as NVIDIA) might no
 
 At the login screen, press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F5</kbd> to switch to a TTY. You'll be prompted to enter a login. At the `login` prompt, enter your username and press <kbd>Enter</kbd>. You'll then be prompted for your password. You will not see your password as you are typing it; just type it and press "Enter."
 
-If you're not able to log in, there could be a few reasons:
+If you're not able to log in, the reason could be:
 
-* Wrong username: Your username may not be the same as your display name. It is often your first name all lowercase, first and last name all lowercase, or first initial and last name all lowercase.
-* Wrong password: You're notified of this at the graphical login greeter.
-* Something is blocking the login.
+* **Wrong username**: your username may not be the same as your display name. It is often your first name all lowercase, first and last name all lowercase, or first initial and last name all lowercase.
+* **Wrong password**: you're notified of this at the graphical login screen.
+* Something else is blocking the login.
 
-The easiest way to confirm your username is by booting into recovery mode, entering a chroot, and running `ls` in the `/home` directory, as outlined in the [Password Reset](/articles/password/) article. If your username and password are both correct, then something else is blocking the login. This is a difficult issue to troubleshoot, and you might want to consider backing up your files from a live disk and [Reinstalling Pop!_OS](/articles/pop-recovery/) or contacting Support for more assistance.
+The easiest way to confirm your username is by booting into recovery mode, entering a chroot, and running `ls` in the `/home` directory, as outlined in the [Password Reset](/articles/password/) article. If your username and password are both correct, then something else is blocking the login. This is a difficult issue to troubleshoot, and you might want to consider backing up your files from a live disk and [Reinstalling Pop!_OS](/articles/install-pop/) or contacting Support for more assistance.
 
 After logging in, you'll be presented with a prompt showing your username, hostname, and a tilde (~) representing your home directory.
 
 ![Login and initial prompt](/images/login-loop/login-initial.png)
 
-Note that you can always return to the graphical login screen by pressing <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F1</kbd>, or by typing `systemctl restart gdm`.
+Note that you can always return to the graphical login screen by pressing <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F1</kbd>, or by typing `sudo systemctl restart gdm`.
 
 ### Move old configuration files out of the way
 
@@ -64,7 +64,7 @@ mv .nv .nv.old
 sudo systemctl reboot
 ```
 
-After removing those files, try logging in again.
+After moving those files and rebooting, try logging in again. (There may be files you need to move other than the common ones listed above.)
 
 ### Reinstall the login manager
 
@@ -82,7 +82,7 @@ sudo apt install --reinstall gdm3 ubuntu-desktop gnome-shell
 sudo systemctl reboot
 ```
 
-After reinstalling those packages, try logging in again.
+After reinstalling those packages and rebooting, try logging in again.
 
 ### Reinstall NVIDIA Driver
 
@@ -117,10 +117,6 @@ sudo apt install system76-driver-nvidia
 
 After the installation has completed, type `sudo systemctl reboot` and try logging in again.
 
-![chown Xauth](/images/login-loop/chown-xauth.png)
+### If these steps don't work...
 
-Switch back to the graphical login with <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F7</kbd> and confirm you can log in.
-
-### If These Steps Don't Work
-
-Contact Support: we have a few more things to try. There are a significant number of processes and files required for your graphical desktop environment to be loaded, and much fewer for the terminal login. As such, you can usually recover your desktop using the command line interface!
+Contact Support! We have a few more things to try. There are a significant number of processes and files required for your graphical desktop environment to be loaded, and much fewer for the terminal login. As such, you can usually recover your desktop using the command line interface!

--- a/_articles/login-loop.md
+++ b/_articles/login-loop.md
@@ -18,41 +18,75 @@ section: pop-ubuntu
 
 ---
 
-Sometimes after an upgrade or under certain conditions, your system might not bring you to the desktop after logging in. If you try logging in and Ubuntu just brings you back to the login screen even though your password was correct, you're experiencing a login loop. There are several causes for login loop:
+Sometimes after an upgrade, your system might not bring you to the desktop after logging in. If you try logging in and you just see a black screen, or Pop!_OS brings you back to the login screen, you're experiencing a login loop. There are several causes for login loops:
 
-* NVIDIA driver issue
-* An update broke the window manager
-* Attempted to start the window manager as root
-* An issue with your user account
-* Login Manager is not working correctly
+* Configuration files in your home directory are not compatible with new versions of software
+* The display/login manager is not working correctly
+* The NVIDIA driver has been updated and is causing an issue
 
-Each cause has a different solution, and certain items (e.g., NVIDIA) might not be applicable to your system. In most cases, you can drop down to a terminal (called a *TTY*) to log in and fix the issue.
+Each cause has a different solution, and certain items (e.g., NVIDIA) might not be applicable to your system. In most cases, you can switch to a full-screen terminal (called a *TTY*) to log in and fix the issue.
 
-**Alternately,** if you can log in but there's no icons on your desktop, see the [Update Broke The Window Manager](#update-broke-window-manager) section below.
+### Switch to a Terminal
 
-### Switch To Terminal
-
-First, confirm that you can log in to your user account. At the login screen, press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F1</kbd> to switch to a TTY. You'll be prompted to enter a login. At the `login` prompt, enter your username and press <kbd>Enter</kbd>. You'll then be prompted for your password. As you type your password, it won't be displayed nor will it be obfuscated.
-
-Once you're logged in, you'll be presented with a prompt showing your username, hostname, and a tilde (~) representing your home directory.
-
-![Login and initial prompt](/images/login-loop/login-initial.png)
+At the login screen, press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F5</kbd> to switch to a TTY. You'll be prompted to enter a login. At the `login` prompt, enter your username and press <kbd>Enter</kbd>. You'll then be prompted for your password. You will not see your password as you are typing it; just type it and press "Enter."
 
 If you're not able to log in, there could be a few reasons:
 
-* Wrong username
-* Something is blocking the login
-* Wrong password (you're notified of this at the graphical login greeter)
+* Wrong username: Your username may not be the same as your display name. It is often your first name all lowercase, first and last name all lowercase, or first initial and last name all lowercase.
+* Wrong password: You're notified of this at the graphical login greeter.
+* Something is blocking the login.
 
-The easiest way to confirm your login (username) is by booting into recovery mode, starting a root shell, and running `ls` in the `/home` directory, as outlined in the [Password Reset](/articles/password/) article. If your login is correct (both username and password) then something else is blocking the login. This is a difficult issue to troubleshoot, and you might want to consider backing up your files from a live disk and [Reinstall Ubuntu](/articles/restore/) or contacting Support for more assistance.
+The easiest way to confirm your username is by booting into recovery mode, entering a chroot, and running `ls` in the `/home` directory, as outlined in the [Password Reset](/articles/password/) article. If your username and password are both correct, then something else is blocking the login. This is a difficult issue to troubleshoot, and you might want to consider backing up your files from a live disk and [Reinstalling Pop!_OS](/articles/pop-recovery/) or contacting Support for more assistance.
 
-If you get logged in without issue, move on to the next steps.
+After logging in, you'll be presented with a prompt showing your username, hostname, and a tilde (~) representing your home directory.
 
-Note that you can always return to the graphical login screen by pressing <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F7</kbd>
+![Login and initial prompt](/images/login-loop/login-initial.png)
+
+Note that you can always return to the graphical login screen by pressing <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F1</kbd>, or by typing `systemctl restart gdm`.
+
+### Move old configuration files out of the way
+
+To determine whether configuration in your home directory is causing the issue, you can create a new user account for testing purposes:
+
+```
+sudo adduser test
+sudo systemctl reboot
+```
+
+If you're able to log in with the test user, the issue is somewhere in your regular user's home folder. Log into the full-screen terminal with your regular user again, and move some of the common configuration files out of the way:
+
+```
+mv .config .config.old
+mv .local .local.old
+mv .cache .cache.old
+mv .nvidia-settings-rc .nvidia-settings-rc.old
+mv .nv .nv.old
+sudo systemctl reboot
+```
+
+After removing those files, try logging in again.
+
+### Reinstall the login manager
+
+You can reinstall GNOME Display Manager (which handles the login screen), along with the desktop environment. On Pop!_OS:
+
+```
+sudo apt install --reinstall gdm3 pop-desktop gnome-shell
+sudo systemctl reboot
+```
+
+Or on Ubuntu:
+
+```
+sudo apt install --reinstall gdm3 ubuntu-desktop gnome-shell
+sudo systemctl reboot
+```
+
+After reinstalling those packages, try logging in again.
 
 ### Reinstall NVIDIA Driver
 
-If your system is equipped with NVIDIA graphics, a recent update might be causing the login issues. Refer to the table below to determine if your system contains NVIDIA graphics.
+If your system is equipped with NVIDIA graphics, a recent update might be causing the login issues. (Usually, NVIDIA driver issues will prevent the login screen from loading at all; however, it's still worth reinstalling if you are unable to log in after the above steps.) Refer to the table below to determine if your system contains NVIDIA graphics:
 
 Always        | Maybe                | Never
 :-------------|:---------------------|:-----
@@ -63,87 +97,29 @@ Bonobo WS     | Thelio               | Galago Pro
 Leopard WS    | Thelio Major         | Darter Pro
 Silverback WS | Thelio Massive       |
 
-Even if your system doesn't have NVIDIA graphics, there's no harm in uninstalling the driver. If it's not installed, nothing will happen. 
-
-To remove the NVIDIA drivers, run the following:
+To remove the NVIDIA driver, run the following:
 
 ```
-sudo apt purge nvidia*
+sudo apt purge *nvidia*
+sudo apt autoremove
+sudo apt clean
 ```
-
-Wait for `apt` to complete, then reboot by typing `reboot` at the prompt.
 
 ![Removing NVIDIA](/images/login-loop/purge-nvidia.png)
 
-After you've rebooted, try logging in. Since the NVIDIA driver was removed, your display might be using a different resolution. This will be corrected after reinstalling the NVIDIA driver. If you can successfully log in, open a terminal by pressing <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd> and run the following command:
+After the NVIDIA driver has been removed, add it back using the following commands:
 
 ```
+sudo apt update
+sudo apt full-upgrade
 sudo apt install system76-driver-nvidia
 ```
 
-After the installation has completed, type `reboot` and confirm you can still log in. If it works, you're all set! If not, try some of the next steps.
-
-### Update Broke Window Manager
-
-In rare cases, you can log in, but there are no icons or launcher on the desktop. Follow the steps above to [Switch To Terminal](#switch-to-terminal), then run the following commands once logged in:
-
-```
-mv ~/.cache/compizconfig-1 ~/cconfig-old
-reboot
-```
-
-After the system reboots, confirm that you can log in and that your icons and launcher are restored. This might change some of your desktop settings such as launcher icon position or desktop background, but it does not affect your files. If you still can't log in, or if this doesn't apply, see the next section.
-
-### Attempted to Start The Window Manager as Root
-
-Perhaps you logged in to the terminal and tried to run `sudo startx` while logged in as your user. X runs as an individual user, so you should *never* run `sudo startx` to start the window manager. Usually, it only changes the permissions on a single file, `~/.Xauthority` which can be reverted from the terminal. Follow the steps above to [Switch To Terminal](#switch-to-terminal) then run the following commands to:
-
-* Confirm the file ownership of .Xauthority
-* Change ownership back to your user *replacing username:username with your actual username*
-* Confirm the updated file ownership of .Xauthority
-
-```
-ls -lah .Xauthority
-sudo chown username:username .Xauthority
-ls -lah .Xauthority
-```
+After the installation has completed, type `sudo systemctl reboot` and try logging in again.
 
 ![chown Xauth](/images/login-loop/chown-xauth.png)
 
 Switch back to the graphical login with <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F7</kbd> and confirm you can log in.
-
-### An issue with your user account
-
-This may be caused by a bad config directory and a new config directory can be created with the following command:
-
-```
-mv ~/.config ~/.config.bk
-```
-
-That will rename the current .config directory in your home directory (directories with period in the beginning of their names are hidden by default) which will allow the OS to create a new folder once it is rebooted:
-
-```
-reboot
-```
-
-### Login Manager is not working correctly
-
-There could also be an issue with the Login Manager. Both Pop!_OS and Ubuntu use GDM as their Login Managers. That package can reinstalled with these commands:
-
-#### Pop!_OS
-
-```
-sudo apt purge gdm3 
-sudo apt install --reinstall gdm3 pop-desktop
-```
-
-#### Ubuntu
-
-
-```
-sudo apt purge gdm3 
-sudo apt install --reinstall gdm3 ubuntu-desktop
-```
 
 ### If These Steps Don't Work
 

--- a/_articles/login-loop.md
+++ b/_articles/login-loop.md
@@ -24,7 +24,7 @@ Sometimes after an upgrade, your system might not bring you to the desktop after
 * The display/login manager is not working correctly
 * The NVIDIA driver has been updated and is causing an issue
 
-Each cause has a different solution, and certain items (e.g., NVIDIA) might not be applicable to your system. In most cases, you can switch to a full-screen terminal (called a *TTY*) to log in and fix the issue.
+Each cause has a different solution, and certain items (such as NVIDIA) might not be applicable to your system. In most cases, you can switch to a full-screen terminal (called a *TTY*) to log in and fix the issue.
 
 ### Switch to a Terminal
 

--- a/_articles/login-loop.md
+++ b/_articles/login-loop.md
@@ -1,6 +1,6 @@
 ---
 layout: article
-title: Can't Log In or No Icons On Desktop
+title: Can't Log In or Black Screen After Logging In
 description: >
   Are you getting stuck in a login loop, even though your password is correct? Do you see a black screen after you log in?
 keywords:

--- a/_articles/login-loop.md
+++ b/_articles/login-loop.md
@@ -2,7 +2,7 @@
 layout: article
 title: Can't Log In or No Icons On Desktop
 description: >
-  Are you getting stuck in a login loop, even though your password is correct? Are you logged in with no desktop icons?
+  Are you getting stuck in a login loop, even though your password is correct? Do you see a black screen after you log in?
 keywords:
   - Support
   - Guides


### PR DESCRIPTION
The "Login Loop" article has become extremely outdated. Among other things, this rewrite contains the following improvements:

- The old article claimed Ctrl-Alt-F1 went to a full-screen terminal and Ctrl-Alt-F7 went to the login screen. The new article correctly reflects that Ctrl-Alt-F1 goes to the login screen, and uses Ctrl-Alt-F5 for the full-screen terminal instead.

- The new article clarifies that your "username" is probably different from the display name on the login screen, and gives some common examples for what your username might be.

- The new article heavily expands the user account-specific portion, including explaining how to test whether the issue is user account-specific by creating a test user, and providing several more configuration dotfiles/directories to move out of the way.

- The new article places the "create a test user" and "move old configuration files out of the way" section above the other sections, as our recent experience indicates this is more often the solution.

- The "reinstalling the login manager" section now also includes reinstalling the desktop environment.

- Reinstalling the NVIDIA driver has been moved to the bottom (since if NVIDIA is the issue, you're probably not able to get to the GUI login screen anyway, and this article would not apply.)

- The "you ran startx as root" section has been removed, because that's an extreme corner-case that we have not seen for a very long time.