### PR TITLE
Add section about apt pin to Installing Ubuntu article

### DIFF
--- a/_articles/install-ubuntu.md
+++ b/_articles/install-ubuntu.md
@@ -112,6 +112,30 @@ If you ordered a system with a discrete NVIDIA graphics card or if you added one
 sudo apt install system76-driver-nvidia
 ```
 
+#### Apt Preferences File
+
+If you are running Ubuntu 19.10 or later, you will need to manually add an apt preferences file to "pin" the System76 repository. This will tell apt to prefer System76 packages over standard Ubuntu packages. Installing the System76 Driver will not be possible until this step is completed.
+
+Create the apt preferences file here:
+
+```
+sudo gedit /etc/apt/preferences.d/system76-apt-preferences
+```
+
+Add the following six lines (seven if you count the space in the middle):
+
+```
+Package: *
+Pin: release o=LP-PPA-system76-dev-stable
+Pin-Priority: 1001
+
+Package: *
+Pin: release o=LP-PPA-system76-dev-pre-stable
+Pin-Priority: 1001
+```
+
+Save the file. Now you should be able to install the System76 Driver as described above.
+
 #### If 'nouveau.modeset=0' Was Used
 
 The `nouveau.modeset=0` modifier should be made default if your machine has NVIDIA hardware. Please run this command to edit the startup options file:


### PR DESCRIPTION
Users cannot install the System76 Driver on Ubuntu 19.10 until an apt preferences file has been manually added. (This is still the case, even after the kernel version change to -7625.) This PR updates the Installing Ubuntu article to include this step, so users can install the System76 Driver on their computers running Ubuntu 19.10.