### PR TITLE
Remove ESC key from sentence

### DIFF
--- a/_articles/pop-recovery.md
+++ b/_articles/pop-recovery.md
@@ -19,7 +19,7 @@ section: pop-ubuntu
 
 The recovery partition on this operating system is a full copy of the Pop!_OS installation disk. It can be used exactly the same as if a live disk copy of Pop!_OS was booted from a USB drive. The existing operating system can be repaired or reinstalled from the recovery mode. You can also perform a refresh install, which allows you to reinstall without losing any user data or data in your home directory, or opt to do a fresh install, which will essentially reset all OS data. Refresh Installs are only available on a fresh install of Pop!_OS 19.04.
 
-To boot into recovery mode, bring up the <u>systemd-boot</u> menu by holding down <kbd>SPACE</kbd> or the <kbd>ESC</kbd> key while the system is booting.  On the menu, choose **Pop!_OS Recovery**.
+To boot into recovery mode, bring up the <u>systemd-boot</u> menu by holding down <kbd>SPACE</kbd> while the system is booting. On the menu, choose **Pop!_OS Recovery**.
 
 ![systemd-boot](/images/pop-recovery/systemd-boot.png)
 


### PR DESCRIPTION
A galp4 customer got confused because our article says he can hold down SPACE or ESC to get into the systemd-boot menu. On products with System76 Open Firmware, ESC will access the firmware menu if it's held down from boot.

This change removes ESC as an option in the Pop Recovery article. This makes the article accurate and easier to follow for System76 Open Firmware users. I am not aware of any time when ESC would work but SPACE would fail for getting in the systemd-boot menu, so this should not negatively affect any other users.