### PR TITLE
Update server setup

### DIFF
--- a/_articles/server-setup.md
+++ b/_articles/server-setup.md
@@ -226,7 +226,7 @@ To setup remote management on the server, connect an additional Ethernet line to
 
 See Intel's user guide for configuring the BMC here:
 
-[Intel BMC User Guide](http://download.intel.com/support/motherboards/server/sb/intel_rmm4_bmc_ews_userguide_r2_8.pdf)
+[Intel BMC User Guide](https://www.intel.com/content/dam/support/us/en/documents/server-products/intel-rmm4-ibmc-userguide.pdf)
 
 To run the jwviewer.jnlp file on the viewing computer, please install this program:
 

--- a/_articles/server-setup.md
+++ b/_articles/server-setup.md
@@ -236,6 +236,14 @@ sudo apt install icedtea-netx
 
 Which will install the program 'javaws' (Java Web Services)
 
+---
+
+#### BMC on the Ibex Pro GPU
+
+On the Ibex Pro GPU, the BMC interface will look slightly different. See the [Gigabyte Server Management Console](https://download.gigabyte.com/FileList/Manual/server_manual_mgt_console_user_guide_ami_v1.x.pdf) manual.
+
+For this machine, the default BMC username is `admin` and the default password is `password`.
+
 ### Additional Server Resources
 
 [Ubuntu Server Information](http://www.ubuntu.com/server)


### PR DESCRIPTION
Currently, the link to the Intel BMC manual in this article is broken.

This PR makes two changes:

- Update the link for the Intel BMC manual (the new link goes to revision 2.9 of the manual, while the dead link used to point to revision 2.8.)

- Add a section about the Ibex Pro GPU, which includes a link to the Gigabyte BMC manual and the default username and password. The Ibex Pro's firmware interface is different from our other servers, so this information is critical when setting up an Ibex Pro system.