### PR TITLE
Populate the image descriptions with meaningful descriptions

### DIFF
--- a/_articles/pop-basics.md
+++ b/_articles/pop-basics.md
@@ -25,28 +25,28 @@ Welcome to the Pop!_OS desktop! By default, it's clean and ready for action.
 
 To navigate within the desktop, either click the <u>Activities</u> button in the top left, or press the <kbd><span class="fl-pop-key"></span></kbd> key on the keyboard.  This will show an overview of all open windows and provide a text box to search your system.
 
-![Pop Desktop](/images/pop-basics/activities-view.png)
+![Activities Menu](/images/pop-basics/activities-view.png)
 
 Click the <u>Show Applications</u> button on the left to show all currently installed programs.
 
-![Pop Desktop](/images/pop-basics/show-applications.png)
+!["Show Applications" Menu](/images/pop-basics/show-applications.png)
 
 Type in any word to search your computer for installed programs, files, and items in the <u>Pop!_Shop</u>.
 
-![Pop Desktop](/images/pop-basics/search.png)
+![Activites Menu Search](/images/pop-basics/search.png)
 
 The <u>Pop!_Shop</u> can be used to install additional software. Just search for programs or browse for them by category, and click the <u>Install</u> button to add them to your computer.
 
-![Pop Desktop](/images/pop-basics/pop-shop.png)
+![Pop!_Shop](/images/pop-basics/pop-shop.png)
 
 You can find options for the current window you're working in using the Menu Bar at the top of the screen.
 
-![Pop Desktop](/images/pop-basics/pop-top-menu.png)
+![Top menu](/images/pop-basics/pop-top-menu.png)
 
 For many applications, additional options are available in a separate menu within the application itself.
 
-![Pop Desktop](/images/pop-basics/pop-app-menu.png)
+![In-app menu](/images/pop-basics/pop-app-menu.png)
 
 The top right menu can be used to adjust volume and screen brightness, connect to WiFi networks, and log out/restart/shut down the computer. You can open the system settings using the gear icon in this menu.
 
-![Pop Desktop](/images/pop-basics/pop-settings.png)
+![Top right menu](/images/pop-basics/pop-settings.png)


### PR DESCRIPTION
Previously, the Pop Basics article's image descriptions were all just "Pop Desktop." This changes the image descriptions so they actually describe what the image shows, in case someone's using a screen reader or an image fails to load.