### PR TITLE
init upload of the first thelio-b1 service manual

### DIFF
--- a/_articles/service-manuals.md
+++ b/_articles/service-manuals.md
@@ -27,5 +27,5 @@ section: repairs-returns
 
 | Desktops     | Service Manual |
 | -------------| ---------------|
-| Thelio       | [thelio-r1](https://system76.com/guides/thelio/r1), [thelio-b1](https://system76.com/guides/thelio/b1) |
+| Thelio       | [thelio-r1](https://system76.com/guides/thelio/r1), [thelio-b1]https://github.com/system76/docs/blob/gh-pages/service-manuals/pdfs/Thelio/B1/thelio-b1-service-manual.pdf |
 | Thelio Major | [thelio-major-r1](https://system76.com/guides/thelio-major/r1), [thelio-major-b1](https://system76.com/guides/thelio-major/b1) |


### PR DESCRIPTION
This is the first PDF of the Thelio b1 service manual that goes over the following items:

- Taking the top case off and placing it back on
- Replace RAM
- Replace Drives
- Replace Thermal Compound
- Specs of the hardware