### PR TITLE
Adding timestamp to articles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+---
+name: Jekyll CI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs: 
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build & Deploy to GitHub Pages
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
+          GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+        uses: BryanSchuetz/jekyll-deploy-gh-pages@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@v1
       - name: Build & Deploy to GitHub Pages
         env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
           GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
           GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
-        uses: BryanSchuetz/jekyll-deploy-gh-pages@master
+          BUILD_DIR: ${{ secrets.BUILD_DIR }}
+          REMOTE_BRANCH: ${{ secrets.REMOTE_BRANCH }}
+        uses: burden/jekyll-deploy-gh-pages@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 _site
-build
 .sass-cache
 Gemfile.lock
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
+build
 .sass-cache
 Gemfile.lock
 *~

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
-
+gem 'jekyll-last-modified-at', group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ collections:
     output: true
 
 # Build settings
+destination: build
 markdown: kramdown
 highlighter: rouge
 permalink: pretty
@@ -21,3 +22,6 @@ kramdown:
 
 plugins:
   - jekyll-redirect-from
+  - jekyll-last-modified-at
+
+exclude: ['.github']

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,6 @@ collections:
     output: true
 
 # Build settings
-destination: build
 markdown: kramdown
 highlighter: rouge
 permalink: pretty

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -6,4 +6,7 @@ layout: default
     <div class="small-12 small-centered medium-10 large-8 columns">
         {{ content }}
     </div>
+    <div class="small-12 small-centered medium-10 large-8 columns timestamp">
+        <p>Article last modified: {% last_modified_at %Y-%m-%d%}</p>
+    </div>
 </div>

--- a/css/main.scss
+++ b/css/main.scss
@@ -2,3 +2,8 @@
 ---
 @charset "utf-8";
 @import url(syntax.css);
+
+.timestamp {
+    text-align: center;
+    padding: 2em 0;
+}


### PR DESCRIPTION
NOTE: DO NOT MAKE CHANGES TO THE `gh-pages` BRANCH

With the addition of the jekyll-last-modified-at plugin, we are no longer able to
rely upon Github to build the site from the `gh-pages` branch because the plugin is
not whitelisted.

Moving forward, please merge changes to the `master` branch which will trigger a build that deploys into the 'public' branch which I've configured as the new Github Pages source. 

+ added jekyll-last-modified-at plugin to project
+ added timestamp to bottom of all articles denoting when the last update was made.
+ added Github Actions for building Jekyll, then pushing the build to `public` branch
+ changed default repo from `gh-pages` to `master` on Github