### PR TITLE
Apply grammar fixes

### DIFF
--- a/_articles/package-manager.md
+++ b/_articles/package-manager.md
@@ -16,7 +16,7 @@ section: pop-ubuntu
 
 ---
 
-If your system complains about a failed upgrade, package managers conflicts, broken upgrades, or other package related issues, there are several common fixes to these problems.  Some package manager issues can be resolved with the graphical update program, but many require the command line.  If you get the red circle in the status bar, run these commands to fix your package manager:
+If your system complains about a failed upgrade, package manager conflicts, broken upgrades, or other package-related issues, there are several common fixes to these problems.  Some package manager issues can be resolved with the graphical update program, but many require the command line.  If you get the red circle in the status bar, run these commands to fix your package manager:
 
 ```
 sudo apt clean


### PR DESCRIPTION
#187 was closed (not merged.) That PR did remove a lot of information, and it looks like it may have also clobbered the password article. However, this particular commit fixes a typo in the first sentence of an article, so I think we should at least merge this one.