### PR TITLE
Change gh-pages to master in edit link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -41,7 +41,7 @@
       <h1 class="small-12 columns greeting">
         <a href="/" title="Back to Support"><i class="fa fa-arrow-left"></i></a>
         {{ page.title }}
-        <a href="https://github.com/system76/docs/blob/gh-pages/{{ page.path }}" class="button"><i class="fa fa-github"></i> Edit on GitHub</a>
+        <a href="https://github.com/system76/docs/blob/master/{{ page.path }}" class="button"><i class="fa fa-github"></i> Edit on GitHub</a>
       </h1>
     </div>
   </header>


### PR DESCRIPTION
The "Edit on GitHub" button currently links to gh-pages, which shows a 404. This will update the edit button to point to master.