### PR TITLE
Changed contribute link in header include to point at edit page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,4 +23,11 @@ plugins:
   - jekyll-redirect-from
   - jekyll-last-modified-at
 
-exclude: ['.github']
+exclude:
+  - '.github'
+  - '.nojekyll'
+  - 'CONTRIBUTE.md'
+  - 'Gemfile'
+  - 'Gemfile.lock'
+  - 'LICENSE.md'
+  - 'README.md'

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -41,7 +41,7 @@
       <h1 class="small-12 columns greeting">
         <a href="/" title="Back to Support"><i class="fa fa-arrow-left"></i></a>
         {{ page.title }}
-        <a href="https://github.com/system76/docs/blob/master/{{ page.path }}" class="button"><i class="fa fa-github"></i> Edit on GitHub</a>
+        <a href="https://github.com/system76/docs/edit/master/{{ page.path }}" class="button"><i class="fa fa-github"></i> Edit on GitHub</a>
       </h1>
     </div>
   </header>


### PR DESCRIPTION
In addition to changing link I also took the opportunity to exclude some of the meta data from Jekyll/Ruby. 