### PR TITLE
update wording

### DIFF
--- a/_articles/desktop-quickstart.md
+++ b/_articles/desktop-quickstart.md
@@ -36,7 +36,7 @@ Press the circular button on the front of the machine after all components are p
 
 ### Set Up User Account
 
-When you power on, you'll be prompted to create a user account, which is the administrative account (root). The password you set for this account will be the main password for when you install applications or updates, or add new users to the computer. In Pop!_OS, you can choose to encrypt your hard drive while setting up the user account.
+When you power on, you'll be prompted to create a user account, which is an administrative account (in the sudo group). The password you set for this account will be the main password for when you install applications or updates, or add new users to the computer. In Pop!_OS, you can choose to encrypt your hard drive while setting up the user account. If Ubuntu was picked during configuration reinstalling the OS will be needed to set up encryption. 
 
 You will be prompted for the encryption passphrase first if you select that option during the account creation process. After the encryption passphrase is set, you will proceed to set up a user account and be prompted to set the administrator password. If you encrypt your hard drive, you will be prompted for the encryption passphrase every time you power on. It's important to write this password down and keep it somewhere safe. If the password is lost or forgotten, you will lose access to the contents of the drive.
 

--- a/_articles/desktop-quickstart.md
+++ b/_articles/desktop-quickstart.md
@@ -36,10 +36,10 @@ Press the circular button on the front of the machine after all components are p
 
 ### Set Up User Account
 
-When you power on, you'll be prompted to create a user account, which is an administrative account (in the sudo group). The password you set for this account will be the main password for when you install applications or updates, or add new users to the computer. In Pop!_OS, you can choose to encrypt your hard drive while setting up the user account. If Ubuntu was picked during configuration reinstalling the OS will be needed to set up encryption. 
+When you power on, you'll be prompted to create a user account, which is an administrative account (in the sudo group). The password you set for this account will be the main password for when you install applications or updates, or add new users to the computer. In Pop!_OS, you can choose to encrypt your hard drive while setting up the user account. If Ubuntu was picked during configuration reinstalling the OS will be needed to set up encryption and instructions for that can be found [here](/articles/install-ubuntu)
 
 You will be prompted for the encryption passphrase first if you select that option during the account creation process. After the encryption passphrase is set, you will proceed to set up a user account and be prompted to set the administrator password. If you encrypt your hard drive, you will be prompted for the encryption passphrase every time you power on. It's important to write this password down and keep it somewhere safe. If the password is lost or forgotten, you will lose access to the contents of the drive.
 
 ### Looking for your additional drives?
 
-This article can be used to [automount the Extra Drives](/articles/extra-drive/).
+This article can be used to [auto-mount the Extra Drives](/articles/extra-drive/).


### PR DESCRIPTION
The default account during set up is not the root account and is instead in the sudo group to make system level changes like installing software and updates.

In order to encrypt the OS for Ubuntu the OS would need to be reinstalling, I included a link to the install Ubuntu article as well.