### PR TITLE
split build and deploy steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
         env:
           PERSONAL_TOKEN: ${{ secrets.GITHUB_KEY }}
           PUBLISH_BRANCH: gh-pages
-          PUBLISH_DIR: ./docs
+          PUBLISH_DIR: ./_site

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,44 @@
 ---
-name: Jekyll CI
 
-on:
-  push:
-    branches:
-      - master
+name: CI
 
-jobs: 
-  build_and_deploy:
+on: push
+
+jobs:
+  Build:
     runs-on: ubuntu-latest
+    
     steps:
-      - uses: actions/checkout@v1
-      - name: Build & Deploy to GitHub Pages
-        env: 
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
-          GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-          GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
-          BUILD_DIR: ${{ secrets.BUILD_DIR }}
-          REMOTE_BRANCH: ${{ secrets.REMOTE_BRANCH }}
-        uses: burden/jekyll-deploy-gh-pages@master
+      - name: Checkout
+        uses: actions/checkout@v1
+      
+      - name: Build
+        run: |
+          docker run \
+          -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
+          jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+
+  Deploy_Github_Pages:
+    name: Deploy (Github Pages)
+    runs-on: ubuntu-latest
+    needs:
+      - Build
+    
+    if: github.ref == 'refs/heads/master'
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      
+      - name: Build
+        run: |
+          docker run \
+          -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
+          jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"
+     
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v2
+        env:
+          PERSONAL_TOKEN: ${{ secrets.GITHUB_KEY }}
+          PUBLISH_BRANCH: gh-pages
+          PUBLISH_DIR: ./docs


### PR DESCRIPTION
- split out the build and deploy parts of CI, so we can check if there is a syntax error in one of the files before deploying
- also uses the same action I use for all the Vue doc pages for deploying, so I know it works
- uses the official docker image for building the docs so it's always up to date
- hopefully more debugging and verbose error messages if something goes wrong