### PR TITLE
remove reference at top to 18.04

### DIFF
--- a/_articles/upgrade-pop.md
+++ b/_articles/upgrade-pop.md
@@ -23,7 +23,7 @@ section: pop
 ---
 Pop!\_OS 20.04 LTS was released April 30, 2020. View the [Release Notes](/articles/Pop!_OS-20.04-LTS-Release-Notes) to learn about new features.
 
-### Upgrading to Pop!\_OS to 20.04 from 19.10 or 18.04
+### Upgrading to Pop!\_OS version 20.04 from 19.10
 
 First, make sure you have applied all updates to your system. You can do this through the Pop!\_Shop, or through the terminal:
 


### PR DESCRIPTION
I *think* the reference at the top to 18.04 is now out of date, correct? So this removes it.