### PR TITLE
Fixed typo: "enviroment" -> "environment"

### DIFF
--- a/_articles/desktop-environment.md
+++ b/_articles/desktop-environment.md
@@ -31,7 +31,7 @@ For Ubuntu, install the `ubuntu-desktop` package instead:
 sudo apt install ubuntu-desktop
 ```
 
-The desktop enviroment is basically the top graphical layer of the OS. The desktop environment is launched by a display manager; Pop!_OS and Ubuntu both use GDM (GNOME Display Manager) by default.
+The desktop environment is basically the top graphical layer of the OS. The desktop environment is launched by a display manager; Pop!_OS and Ubuntu both use GDM (GNOME Display Manager) by default.
 
 If multiple desktop environments are installed, GDM will display a gear icon, which will allow you to select the desktop environment you want to launch. You will need to either reboot or restart your display manager using `sudo systemctl restart gdm` before a newly-installed desktop environment will show up in the list of options.
 


### PR DESCRIPTION
3rd paragraph in (after the `sudo` excerpts) has a typo (see title). This change amends that typo.