### PR TITLE
VirtualBox default resolution sometimes cannot fit installer

### DIFF
--- a/_articles/install-in-vm.md
+++ b/_articles/install-in-vm.md
@@ -86,3 +86,11 @@ Go to your Downloads area and select the ISO image you downloaded and click "Ope
 Click on the Start button on the toolbar. It is the icon with the green arrow.
 
 That's it!  You're done!  Visit our [Pop!_OS page](http://pop.system76.com/) and please give us feedback on how Pop!_OS is working for you!
+
+#### "The screen resolution is too small!"
+
+If you notice that the installer for Pop!_OS is too large to fit into the default screen resolution by VirtualBox, try this:
+
+Move the installation window slightly (but not completely) out of the way, right-click on the desktop and select "Display Settings". From here you will be able to change the virtual machine's screen resolution. Increase the virtual machine resolution slightly, then click Apply in the top right-hand corner.
+
+You will now be able to continue with the installation.

--- a/_articles/install-in-vm.md
+++ b/_articles/install-in-vm.md
@@ -91,6 +91,6 @@ That's it!  You're done!  Visit our [Pop!_OS page](http://pop.system76.com/) and
 
 If you notice that the installer for Pop!_OS is too large to fit into the default screen resolution in VirtualBox, try this:
 
-Move the installation window slightly (but not completely) out of the way, right-click on the desktop and select "Display Settings". From here you will be able to change the virtual machine's screen resolution. Increase the virtual machine resolution from the default 800x600 to 1024x768 or adove, then click Apply in the top right-hand corner.
+Move the installation window slightly (but not completely) out of the way, right-click on the desktop and select "Display Settings". From here you will be able to change the virtual machine's screen resolution. Increase the virtual machine resolution from the default 800x600 to 1024x768 or above, then click Apply in the top right-hand corner.
 
 You will now be able to continue with the installation.

--- a/_articles/install-in-vm.md
+++ b/_articles/install-in-vm.md
@@ -27,14 +27,6 @@ Once you have that accomplished run VirtualBox.
 
 This is the initial screen of VirtualBox after freshly installing on your OS.  Click on the "New" button on the top left corner.  It should be clearly marked with a colorful blue icon.
 
-#### "The screen resolution is too small!"
-
-If you notice that the installer for Pop!_OS is too large to fit into the default screen resolution in VirtualBox, try this:
-
-Move the installation window slightly (but not completely) out of the way, right-click on the desktop and select "Display Settings". From here you will be able to change the virtual machine's screen resolution. Increase the virtual machine resolution slightly, then click Apply in the top right-hand corner.
-
-You will now be able to continue with the installation.
-
 ### Step 2
 
 ![Name the VM](/images/install-in-a-vm/Create_VM_name.png)
@@ -94,3 +86,11 @@ Go to your Downloads area and select the ISO image you downloaded and click "Ope
 Click on the Start button on the toolbar. It is the icon with the green arrow.
 
 That's it!  You're done!  Visit our [Pop!_OS page](http://pop.system76.com/) and please give us feedback on how Pop!_OS is working for you!
+
+#### "The screen resolution is too small!"
+
+If you notice that the installer for Pop!_OS is too large to fit into the default screen resolution in VirtualBox, try this:
+
+Move the installation window slightly (but not completely) out of the way, right-click on the desktop and select "Display Settings". From here you will be able to change the virtual machine's screen resolution. Increase the virtual machine resolution slightly, then click Apply in the top right-hand corner.
+
+You will now be able to continue with the installation.

--- a/_articles/install-in-vm.md
+++ b/_articles/install-in-vm.md
@@ -27,6 +27,14 @@ Once you have that accomplished run VirtualBox.
 
 This is the initial screen of VirtualBox after freshly installing on your OS.  Click on the "New" button on the top left corner.  It should be clearly marked with a colorful blue icon.
 
+#### "The screen resolution is too small!"
+
+If you notice that the installer for Pop!_OS is too large to fit into the default screen resolution in VirtualBox, try this:
+
+Move the installation window slightly (but not completely) out of the way, right-click on the desktop and select "Display Settings". From here you will be able to change the virtual machine's screen resolution. Increase the virtual machine resolution slightly, then click Apply in the top right-hand corner.
+
+You will now be able to continue with the installation.
+
 ### Step 2
 
 ![Name the VM](/images/install-in-a-vm/Create_VM_name.png)
@@ -86,11 +94,3 @@ Go to your Downloads area and select the ISO image you downloaded and click "Ope
 Click on the Start button on the toolbar. It is the icon with the green arrow.
 
 That's it!  You're done!  Visit our [Pop!_OS page](http://pop.system76.com/) and please give us feedback on how Pop!_OS is working for you!
-
-#### "The screen resolution is too small!"
-
-If you notice that the installer for Pop!_OS is too large to fit into the default screen resolution in VirtualBox, try this:
-
-Move the installation window slightly (but not completely) out of the way, right-click on the desktop and select "Display Settings". From here you will be able to change the virtual machine's screen resolution. Increase the virtual machine resolution slightly, then click Apply in the top right-hand corner.
-
-You will now be able to continue with the installation.

--- a/_articles/install-in-vm.md
+++ b/_articles/install-in-vm.md
@@ -91,6 +91,6 @@ That's it!  You're done!  Visit our [Pop!_OS page](http://pop.system76.com/) and
 
 If you notice that the installer for Pop!_OS is too large to fit into the default screen resolution in VirtualBox, try this:
 
-Move the installation window slightly (but not completely) out of the way, right-click on the desktop and select "Display Settings". From here you will be able to change the virtual machine's screen resolution. Increase the virtual machine resolution slightly, then click Apply in the top right-hand corner.
+Move the installation window slightly (but not completely) out of the way, right-click on the desktop and select "Display Settings". From here you will be able to change the virtual machine's screen resolution. Increase the virtual machine resolution from the default 800x600 to 1024x768 or adove, then click Apply in the top right-hand corner.
 
 You will now be able to continue with the installation.

--- a/_articles/install-in-vm.md
+++ b/_articles/install-in-vm.md
@@ -89,7 +89,7 @@ That's it!  You're done!  Visit our [Pop!_OS page](http://pop.system76.com/) and
 
 #### "The screen resolution is too small!"
 
-If you notice that the installer for Pop!_OS is too large to fit into the default screen resolution by VirtualBox, try this:
+If you notice that the installer for Pop!_OS is too large to fit into the default screen resolution in VirtualBox, try this:
 
 Move the installation window slightly (but not completely) out of the way, right-click on the desktop and select "Display Settings". From here you will be able to change the virtual machine's screen resolution. Increase the virtual machine resolution slightly, then click Apply in the top right-hand corner.
 


### PR DESCRIPTION
Adding a clarification for this should help those - such as myself - who were initially lost for solutions when installing Pop in a VM, due to the inability to change the screen resolution directly from VirtualBox without Guest Additions installed.