### PR TITLE
Add gaze15 disclaimer for Pluggable dock and fix typos

### DIFF
--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -42,7 +42,7 @@ sudo apt install dkms
 
 To download the newest [DisplayLink driver](http://www.displaylink.com/downloads/ubuntu) with the link in orange.
 
-To install the DisplayLink Driver open the Terminal and move to the Download directory like so: (the version for the driver may change so look at the file name and change it accordly.)
+To install the DisplayLink Driver, open the Terminal and move to the Downloads directory (the version for the driver may change, so look at the file name and change it accordingly):
 
 ```
 cd Downloads

--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -22,12 +22,12 @@ section: accessories
 ### System76-tested docks:
 
 We have tested the following docks:
- - [Plugable UD-CA1A](https://plugable.com/products/ud-ca1a/) [works with NVIDIA and Intel systems] (**)
+ - [Plugable UD-CA1A](https://plugable.com/products/ud-ca1a/) [works with NVIDIA and Intel systems] <sup>1,2,3</sup>
  
 ### Community-tested docks:
 
 Community members have reported that the following docks work with our products:
- - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/206) on an Intel system] (**)
+ - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/206) on an Intel system] <sup>1</sup>
  - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [[community-tested](https://github.com/system76/docs/pull/231) on an Intel system]
 
 ### For Intel systems
@@ -59,5 +59,6 @@ sudo displaylink-installer uninstall
 
 For installing the NVIDIA Driver that we provide you can use this support article: [System76 NVIDIA Driver](http://support.system76.com/articles/system76-driver/).
 
-(*) NVIDIA cards have some minor graphic issues with what is rendered under the mouse as well as scrollbars.
-(**) Does not need the DisplayLink Driver installed to work.
+<sup>1</sup> Does not need the DisplayLink Driver installed to work.  
+<sup>2</sup> On the Gazelle 15 (gaze15), requires GTX 1660 Ti graphics for video output via DisplayPort over USB-C.  
+<sup>3</sup> NVIDIA cards have some minor graphic issues with what is rendered under the mouse as well as scrollbars.


### PR DESCRIPTION
This PR adds a disclaimer for the Pluggable dock that we recommend pointing out that video output on the Gazelle 15 requires GTX 1660 Ti graphics (since the 1650/1650 Ti version does not support DisplayPort over USB-C.)

Since we now have three disclaimers, I changed the asterisks to superscripted numbers instead to make them easier to follow.

Also fixed a couple of small typos that have been pointed out to us previously.