### PR TITLE
Remove trailing dash from package names

### DIFF
--- a/_articles/add-a-printer-pop.md
+++ b/_articles/add-a-printer-pop.md
@@ -64,7 +64,7 @@ sudo apt install --reinstall cups cups-client
 This will reinstall <u>CUPS</u>, the main printing software, which can help with generic issues.
 
 ```
-sudo apt install --reinstall ~n^system-config-printer-
+sudo apt install --reinstall ~n^system-config-printer
 ```
 
 This will reinstall the system control panel if the settings are not available.

--- a/_articles/add-a-printer-ubuntu.md
+++ b/_articles/add-a-printer-ubuntu.md
@@ -66,7 +66,7 @@ sudo apt install --reinstall cups cups-client
 This will reinstall <u>CUPS</u>, the main printing software, which can help with generic issues.
 
 ```
-sudo apt install --reinstall ~n^system-config-printer-
+sudo apt install --reinstall ~n^system-config-printer
 ```
 
 This will reinstall the system control panel if the settings are not available.


### PR DESCRIPTION
https://github.com/system76/docs/pull/424 was merged prematurely and the current command shown (`sudo apt install --reinstall ~n^system-config-printer-`) would cause pop-desktop and gnome-control-center to be removed (because a trailing minus sign tells apt to remove packages matching that pattern if they're installed, and those packages are required by pop-desktop.)

This fixes the command by removing the hyphen at the end, which means those packages will be reinstalled instead of removed, which was the intention of the article before the previous PR.