### PR TITLE
Separate transition to open firmware and firmware update articles

### DIFF
--- a/_articles/system-firmware.md
+++ b/_articles/system-firmware.md
@@ -137,4 +137,4 @@ If you’re receiving the firmware update notification but there are no updates 
 
 ### Switching Between Proprietary Firmware and System76 Open Firmware
 
-If you would like to transition from proprietary firmware to System76 Open Firmware, on a supported model, please view [this article](/articles/transition-firmware/)
+If you would like to transition from proprietary firmware to System76 Open Firmware (on a supported model), please view [this article](/articles/transition-firmware/).

--- a/_articles/system-firmware.md
+++ b/_articles/system-firmware.md
@@ -25,7 +25,7 @@ These instructions are for System76 owners who have been prompted for a firmware
 
 ### Starting the Update (GUI)
 
-In Pop!_OS, you can check for firmware updates using **Settings -> Firmware**.
+In Pop!\_OS, you can check for firmware updates using **Settings -> Firmware**.
 
 ![Firmware settings in Pop!_OS](/images/system-firmware/gui-pop.jpg)
 
@@ -70,7 +70,7 @@ After the system powers off, **press the power button** to turn it back on. On m
 
 ### Disabling the ME
 
-For laptops not running Open Firmware, a few extra steps may be required after an update to ensure the Intel ME is disabled. 
+For laptops not running Open Firmware, a few extra steps may be required after an update to ensure the Intel ME is disabled.
 
 Depending on the model, two blue boxes may appear in succession with a message about the CMOS. **Press <kbd>Enter</kbd>** to dismiss each one. The system may also power off and on again at this point.
 
@@ -94,7 +94,7 @@ Navigate to the **Exit** section in the left sidebar, then select **Exit Saving 
 
 ### Updating on Other OS's
 
-If your system is running another Linux-based OS installed with an EFI System Partition (ESP), then you can update your firmware using a live disk of Pop!_OS. First, create a live disk using one of the following articles:
+If your system is running another Linux-based OS installed with an EFI System Partition (ESP), then you can update your firmware using a live disk of Pop!\_OS. First, create a live disk using one of the following articles:
 
 - [Live Disk creation on Pop!_OS](/articles/pop-live-disk/)
 - [Live Disk creation on Other OS's](/articles/live-disk/)
@@ -135,52 +135,6 @@ After the System76 Driver is installed and the EFI partition has been mounted us
 
 If you’re receiving the firmware update notification but there are no updates available, then your system’s Intel ME may be turned on. Follow the above instructions to [disable the ME](#disabling-the-me).
 
-## Switching Between Open and Proprietary Firmware
+### Switching Between Proprietary Firmware and System76 Open Firmware
 
-Some models shipped with proprietary firmware, but later received support for [System76 Open Firmware](https://github.com/system76/firmware-open). A list of models that support Open Firmware can be found [here](https://github.com/system76/firmware-open/#supported-models).
-
-### Differences between Open and Proprietary Firmware
-
-Open Firmware is open-source, meaning the source code is available for users and developers to read and modify as they please. Proprietary firmware is developed by the upstream motherboard manufacturers, and its source code is not available for viewing or modification. You can read about the benefits of using open-source firmware [here](https://blog.system76.com/post/623810010985742337/open-up-benefits-of-open-source-firmware).
-
-Because Open Firmware is intended to be lightweight and simple to use, there are less options available in the UEFI setup menu for Open Firmware than for proprietary firmware. Notably:
-
-* Many features are enabled by default in Open Firmware, but are not present in the UEFI setup menu. This includes:
-  * Hardware virtualization (Intel VT-D/AMD-V) - can be disabled by the OS via a kernel boot option.
-  * Hyperthreading - can be disabled by the OS via a kernel boot option.
-  * Thunderbolt security - devices must be allowed by the user within the OS.
-  * Battery thresholds - can be set by the user within the OS.
-* Some features are present in proprietary firmware but are not available in Open Firmware, including:
-  * Intel ME - always disabled.
-  * Secure Boot - always disabled.
-  * Self-encryptiong storage drives - not supported (note that the full-disk encryption used in Pop!_OS does not require this firmware-level feature.)
-
-Below is a comparison between the UEFI setup menu on proprietary firmware (left) and Open Firmware (right):
-
-![Proprietary vs. Open Firmware](/images/system-firmware/proprietary-vs-open.webp)
-
-### Transitioning to Open Firmware
-
-If you are currently running proprietary firmware and would like to transition to Open Firmware, follow the [steps above](#starting-the-update-cli) to start the update from the command line, but use the `--open` option when scheduling the update:
-
-```
-sudo system76-firmware-cli schedule --open
-```
-
-### Reverting to Proprietary Firmware
-
-If you are running Open Firmware and need to revert to proprietary firmware (for example, if you require a specific feature not yet present in Open Firmware), you can transition back to proprietary firmware using the `--proprietary` option:
-
-```
-sudo system76-firmware-cli schedule --proprietary
-```
-
-### Checking the Current Firmware Version
-
-You can check your current firmware version using this command:
-
-```
-sudo dmidecode | grep Version:
-```
-
-If the first line of output is a short, decimal-separated number such as `1.07.05`, then you are running proprietary firmware. If the output is a longer, date-based number such as `2020-09-03_9c310f0`, then you are running Open Firmware.
+If you would like to transition from proprietary firmware to System76 Open Firmware, on a supported model, please view [this article](/articles/transition-firmware/)

--- a/_articles/transition-firmware.md
+++ b/_articles/transition-firmware.md
@@ -16,13 +16,11 @@ section: software-applications
 Some models shipped with proprietary firmware, but later received support for [System76 Open Firmware](https://github.com/system76/firmware-open) and [System76 Open EC](https://github.com/system76/ec). Below is a list of these models:
 
 - Adder WS (addw2)
-    - Was shipped with proprietary firmware. Switching will install System76 Open Firmware and System76 Open EC.
-- Darter Pro (darp6)
-    - Was shipped with System76 Open Firmware, but proprietary EC. Switching will install System76 Open EC.
 - Gazelle (gaze15)
-    - Was shipped with proprietary firmware. Switching will install System76 Open Firmware and System76 Open EC.
 
-### Differences between Open and Proprietary Firmware
+This list may expand in the future, as more models are ported.
+
+### Differences between System76 Open Firmware and Proprietary Firmware
 
 System76 Open Firmware is primarily open-source, meaning the source code is available for users and developers to read and modify as they please. Proprietary firmware is developed by the upstream motherboard manufacturers, and its source code is not available for viewing or modification. You can read about the benefits of using open-source firmware [here](https://blog.system76.com/post/623810010985742337/open-up-benefits-of-open-source-firmware).
 

--- a/_articles/transition-firmware.md
+++ b/_articles/transition-firmware.md
@@ -1,0 +1,86 @@
+---
+layout: article
+title: Switching Between Proprietary Firmware and System76 Open Firmware
+description: >
+  How to transition from proprietary firmware to System76 Open Firmware on supported models.
+keywords:
+  - Firmware
+image: http://support.system76.com/images/system76.png
+hidden: false
+section: software-applications
+
+---
+
+## Switching Between Proprietary Firmware and System76 Open Firmware
+
+Some models shipped with proprietary firmware, but later received support for [System76 Open Firmware](https://github.com/system76/firmware-open) and [System76 Open EC](https://github.com/system76/ec). Below is a list of these models:
+
+- Adder WS (addw2)
+    - Was shipped with proprietary firmware. Switching will install System76 Open Firmware and System76 Open EC.
+- Darter Pro (darp6)
+    - Was shipped with System76 Open Firmware, but proprietary EC. Switching will install System76 Open EC.
+- Gazelle (gaze15)
+    - Was shipped with proprietary firmware. Switching will install System76 Open Firmware and System76 Open EC.
+
+### Differences between Open and Proprietary Firmware
+
+System76 Open Firmware is primarily open-source, meaning the source code is available for users and developers to read and modify as they please. Proprietary firmware is developed by the upstream motherboard manufacturers, and its source code is not available for viewing or modification. You can read about the benefits of using open-source firmware [here](https://blog.system76.com/post/623810010985742337/open-up-benefits-of-open-source-firmware).
+
+Because System76 Open Firmware is intended to be lightweight and simple to use, there are less options available in the UEFI setup menu than for proprietary firmware. Notably:
+
+* Many features are enabled by default in Open Firmware, but are not present in the UEFI setup menu. This includes:
+  * Hardware virtualization (Intel VT-D/AMD-V) - can be disabled by the OS via a kernel boot option.
+  * Hyperthreading - can be disabled by the OS via a kernel boot option.
+  * Thunderbolt security - devices must be allowed by the user within the OS.
+  * Battery thresholds - can be set by the user within the OS.
+* Some features are present in proprietary firmware but are not available in Open Firmware, including:
+  * Intel ME - always disabled.
+  * Secure Boot - always disabled.
+  * Self-encryptiong storage drives - not supported (note that the full-disk encryption used in Pop!\_OS does not require this firmware-level feature.)
+
+Below is a comparison between the UEFI setup menu on proprietary firmware (left) and System76 Open Firmware (right):
+
+![Proprietary vs. Open Firmware](/images/system-firmware/proprietary-vs-open.webp)
+
+### Checking the Current Firmware Version
+
+You can check your current firmware version using this command:
+
+```
+cat /sys/class/dmi/id/bios_version
+```
+
+If the output is a short, decimal-separated number such as `1.07.05`, then you are running proprietary firmware. If the output is a longer, date-based number such as `2020-09-03_9c310f0`, then you are running System76 Open Firmware.
+
+### Installing the command-line updater
+
+Before switching between proprietary firmware and System76 Open Firmware, the command line updater must be installed by running the following commands in a terminal:
+
+```
+sudo apt update
+sudo apt install system76-firmware
+```
+
+### Transitioning to System76 Open Firmware
+
+If you are running proprietary firmware and would like to transition to System76 Open Firmware, follow the [steps above](#installing-the-command-line-updater) to install the updater from the command line, then run the following command to schedule the update:
+
+```
+sudo system76-firmware-cli schedule --open
+```
+
+You may then follow the [steps below](#performing-the-update) to perform the update.
+
+### Reverting to Proprietary Firmware
+
+If you are running System76 Open Firmware and need to revert to proprietary firmware (for example, if you require a specific feature not yet present in System76 Open Firmware), follow the [steps above](#installing-the-command-line-updater) to install the updater from the command line, then run the following command to schedule the update:
+
+```
+sudo system76-firmware-cli schedule --proprietary
+```
+
+You may then follow the [steps below](#performing-the-update) to perform the update.
+
+### Performing the update
+
+Reboot the system using `sudo systemctl reboot` to proceed with the update, or use `sudo system76-firmware-cli unschedule` to cancel the update. For more information about the firmware upgrade process, please view the [Update System Firmware](/articles/system-firmware) article.

--- a/_articles/transition-firmware.md
+++ b/_articles/transition-firmware.md
@@ -18,7 +18,7 @@ Some models shipped with proprietary firmware, but later received support for [S
 - Adder WS (addw2)
 - Gazelle (gaze15)
 
-This list may expand in the future, as more models are ported.
+This list may expand in the future as more models are ported.
 
 ### Differences between System76 Open Firmware and Proprietary Firmware
 


### PR DESCRIPTION
I also escaped some instances of Pop!_OS that were not markdown escaped. Some parsers care, others don't.