### PR TITLE
Fixed typo.

### DIFF
--- a/_articles/switch-from-macos-to-popos.md
+++ b/_articles/switch-from-macos-to-popos.md
@@ -511,7 +511,7 @@ LMMS, Ardour and Audacity are all available in the Pop!\_Shop.
 ## [Development](#development)
 
 **macOS**
-  - Xcode (avaiable in the App Store)
+  - Xcode (available in the App Store)
 
 
 **Pop!\_OS**


### PR DESCRIPTION
Changed avaiable top available in the Development section under macOS, - Xcode.