### PR TITLE
Fix Typo

### DIFF
--- a/_articles/upgrade-pop.md
+++ b/_articles/upgrade-pop.md
@@ -44,7 +44,7 @@ Once the download is complete, you will receive a second notification saying the
 
 Click on the notification and your computer will restart to the upgrade screen.
 
-After the upgrade is finished, you will be taken back to the login page, and voila! Your system is now running Pop!\_OS 20.04!
+After the upgrade is finished, you will be taken back to the login page, and voila! Your system is now running Pop!\_OS 20.10!
 
 ### Backup Your Files
 


### PR DESCRIPTION
After upgrading from Pop_OS 20.04 - user would be running Pop_OS 20.10. The last sentence on L47 should read: "Your system is now running Pop_OS 20.10!"

This is a small issue - but could be confusing to some readers. :thinking: 