### PR TITLE
replace commands

### DIFF
--- a/_articles/bootloader.md
+++ b/_articles/bootloader.md
@@ -83,7 +83,8 @@ Run these commands based on what type of disk you have:
 sudo mount /dev/nvme0n1p2 /mnt
 sudo mount /dev/nvme0n1p1 /mnt/boot/efi
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
-sudo cp /etc/resolv.conf /mnt/etc/
+sudo cp -n /etc/resolv.conf /mnt/etc/
+
 sudo chroot /mnt
 apt install --reinstall grub-efi-amd64 linux-generic linux-headers-generic
 update-initramfs -c -k all
@@ -96,7 +97,8 @@ sudo update-grub
 sudo mount /dev/sda2 /mnt
 sudo mount /dev/sda1 /mnt/boot/efi
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
-sudo cp /etc/resolv.conf /mnt/etc/
+sudo cp -n /etc/resolv.conf /mnt/etc/
+
 sudo chroot /mnt
 apt install --reinstall grub-efi-amd64 linux-generic linux-headers-generic
 update-initramfs -c -k all
@@ -120,7 +122,8 @@ Run these commands based on what type of disk you have:
 ```
 sudo mount /dev/nvme0n1p2 /mnt
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
-sudo cp /etc/resolv.conf /mnt/etc/
+sudo cp -n /etc/resolv.conf /mnt/etc/
+
 sudo chroot /mnt
 apt install --reinstall grub-efi-amd64 linux-generic linux-headers-generic
 update-initramfs -c -k all
@@ -132,7 +135,8 @@ sudo update-grub
 ```
 sudo mount /dev/sda2 /mnt
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
-sudo cp /etc/resolv.conf /mnt/etc/
+sudo cp -n /etc/resolv.conf /mnt/etc/
+
 sudo chroot /mnt
 apt install --reinstall grub-efi-amd64 linux-generic linux-headers-generic
 update-initramfs -c -k all
@@ -157,7 +161,8 @@ Run these commands based on what type of disk you have:
 sudo mount /dev/nvme0n1p3 /mnt
 sudo mount /dev/nvme0n1p1 /mnt/boot/efi
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
-sudo cp /etc/resolv.conf /mnt/etc/
+sudo cp -n /etc/resolv.conf /mnt/etc/
+
 sudo chroot /mnt
 apt install --reinstall linux-generic linux-headers-generic
 update-initramfs -c -k all
@@ -171,7 +176,8 @@ sudo bootctl --path=/mnt/boot/efi install
 sudo mount /dev/sda3 /mnt
 sudo mount /dev/sda1 /mnt/boot/efi
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
-sudo cp /etc/resolv.conf /mnt/etc/
+sudo cp -n /etc/resolv.conf /mnt/etc/
+
 sudo chroot /mnt
 apt install --reinstall linux-generic linux-headers-generic
 update-initramfs -c -k all

--- a/_articles/pop-20.10-upgrade-help.md
+++ b/_articles/pop-20.10-upgrade-help.md
@@ -131,7 +131,7 @@ Next we will need to mount the required paths for the chroot to function.
 ```
 sudo mount /dev/sda1 /mnt/boot/efi
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
-sudo cp /etc/resolv.conf /mnt/etc/
+sudo cp -n /etc/resolv.conf /mnt/etc/
 sudo chroot /mnt
 ```
 
@@ -139,7 +139,7 @@ sudo chroot /mnt
 ```
 sudo mount /dev/nvme0n1p1 /mnt/boot/efi
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
-sudo cp /etc/resolv.conf /mnt/etc/
+sudo cp -n /etc/resolv.conf /mnt/etc/
 sudo chroot /mnt
 ```
 

--- a/_articles/pop-recovery.md
+++ b/_articles/pop-recovery.md
@@ -91,7 +91,8 @@ The EFI partition is usually around 512MB so that would be the partition that we
 ```
 sudo mount /dev/sda1 /mnt/boot/efi
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
-sudo cp /etc/resolv.conf /mnt/etc/
+sudo cp -n /etc/resolv.conf /mnt/etc/
+/
 sudo chroot /mnt
 ```
 OR for NVMe drives:
@@ -99,7 +100,8 @@ OR for NVMe drives:
 ```
 sudo mount /dev/nvme0n1p1 /mnt/boot/efi
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
-sudo cp /etc/resolv.conf /mnt/etc/
+sudo cp -n /etc/resolv.conf /mnt/etc/
+/
 sudo chroot /mnt
 ```
 


### PR DESCRIPTION
This affects any articles where we have the following command:
sudo cp /etc/resolv.conf /mnt/etc/

If we change it to:
sudo cp -n /etc/resolv.conf /mnt/etc/

then customers won't get an error message and possibly freak out

I've found this in the following but might be in more areas.
https://support.system76.com/articles/bootloader/
https://support.system76.com/articles/pop-recovery/