### PR TITLE
Add note for executing shell script

### DIFF
--- a/_articles/keyboard-shortcuts.md
+++ b/_articles/keyboard-shortcuts.md
@@ -42,7 +42,7 @@ Enter the information about your shortcut, including what the name will be, the 
 
 Then click "Add", and your shortcut will be active.
 
-*Note*: For executing shell script, use absolute path instead of relative path. Example: `sh /home/username/Documents/script.sh` instead of `sh ~/Documents/script.sh`
+*Note*: In order to execute a shell script, use its absolute path instead of its relative path. Example: `sh /home/username/Documents/script.sh` instead of `sh ~/Documents/script.sh`
 
 You can see all your custom shortcuts at the bottom of the shortcut list, and can click on any of them to modify them.
 

--- a/_articles/keyboard-shortcuts.md
+++ b/_articles/keyboard-shortcuts.md
@@ -42,6 +42,8 @@ Enter the information about your shortcut, including what the name will be, the 
 
 Then click "Add", and your shortcut will be active.
 
+*Note*: For executing shell script, use absolute path instead of relative path. Example: `sh /home/username/Documents/script.sh` instead of `sh ~/Documents/script.sh`
+
 You can see all your custom shortcuts at the bottom of the shortcut list, and can click on any of them to modify them.
 
 ![Custom Shortcuts]({{site.baseurl}}/images/keyboard-shortcuts/custom-shortcuts.png)


### PR DESCRIPTION
Adding a note for executing shell script via custom shortcut.

Since other distro like Linux Mint has an option to browse to the script and handle by itself, in PopOS we only have command, so a note will help future users.