### PR TITLE
Added ThinkPad Thunderbolt 3 Workstation Dock Gen 2

### DIFF
--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -72,7 +72,7 @@ Community members have reported that the following docks work with our products:
  - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/206) on an Intel system] <sup>1</sup>
  - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [[community-tested](https://github.com/system76/docs/pull/231) on an Intel system]
    - Requires extra configuration for suspend/resume to work.
- - [ThinkPad Thunderbolt 3 Workstation Dock Gen 2](https://www.lenovo.com/us/en/accessories-and-monitors/docking/universal-cable-docks-thunderbolt/TBT-WS-Dock-Gen-2/p/40ANY230US) [[community-tested](https://github.com/system76/docs/pull/999) on a `galp5`]
+ - [ThinkPad Thunderbolt 3 Workstation Dock Gen 2](https://www.lenovo.com/us/en/accessories-and-monitors/docking/universal-cable-docks-thunderbolt/TBT-WS-Dock-Gen-2/p/40ANY230US) [[community-tested](https://github.com/system76/docs/pull/999) on an Intel sytem] <sup>1</sup>
 
 ### For Intel systems
 

--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -72,7 +72,7 @@ Community members have reported that the following docks work with our products:
  - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/206) on an Intel system] <sup>1</sup>
  - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [[community-tested](https://github.com/system76/docs/pull/231) on an Intel system]
    - Requires extra configuration for suspend/resume to work.
- - [ThinkPad Thunderbolt 3 Workstation Dock Gen 2](https://www.lenovo.com/us/en/accessories-and-monitors/docking/universal-cable-docks-thunderbolt/TBT-WS-Dock-Gen-2/p/40ANY230US) [[community-tested](https://github.com/system76/docs/pull/999) on an Intel sytem] <sup>1</sup>
+ - [ThinkPad Thunderbolt 3 Workstation Dock Gen 2](https://www.lenovo.com/us/en/accessories-and-monitors/docking/universal-cable-docks-thunderbolt/TBT-WS-Dock-Gen-2/p/40ANY230US) [[community-tested](https://github.com/system76/docs/pull/517) on an Intel sytem] <sup>1</sup>
 
 ### For Intel systems
 

--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -72,6 +72,7 @@ Community members have reported that the following docks work with our products:
  - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/206) on an Intel system] <sup>1</sup>
  - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [[community-tested](https://github.com/system76/docs/pull/231) on an Intel system]
    - Requires extra configuration for suspend/resume to work.
+ - [ThinkPad Thunderbolt 3 Workstation Dock Gen 2](https://www.lenovo.com/us/en/accessories-and-monitors/docking/universal-cable-docks-thunderbolt/TBT-WS-Dock-Gen-2/p/40ANY230US) [[community-tested](https://github.com/system76/docs/pull/999) on a `galp5`]
 
 ### For Intel systems
 


### PR DESCRIPTION
I'm using a ThinkPad Thunderbolt Workstation Dock Gen 2 (40ANY230CH) with a Galago Pro `galp5`.
Peripherals connected to the Dock:

* Dell 4K 24" monitor using DisplayPort. At work I tried the same dock with a Samsung 27" 4K monitor.
* Logitec USB receiver for a wireless MX Anywhere 2S mouse
* Wired USB Keyboard (Leopold FC660C)
* Ethernet
* Headphone using the 3.5mm Headphone Jack

No additional drivers were needed, everything just worked.

Only problem so far: The Galago Pro doesn't charge through the dock. [Link to related issue](https://github.com/system76/firmware-open/issues/144)