### PR TITLE
Add Dell WD19 and Plugable ud-ultcdl dock info

### DIFF
--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -70,10 +70,10 @@ Community members have reported that the following docks work with our products:
  - [Dell DS1000](https://www.dell.com/support/manuals/us/en/04/dell-dockstand-ds1000/ds1000_docking_stand_ug_publication/technical-specifications?guid=guid-1ad58fe1-dd33-4ebc-bac1-8e6a9083eb35&lang=en-us) [[community-tested](https://github.com/system76/docs/pull/431) on an Intel system]
    - Ethernet port not tested.
  - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/206) on an Intel system] <sup>1</sup>
- - [Dell WD19 Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](#) on an Intel system] <sup>1</sup>
- - [Plugable UD-ULTCDL Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](#) on an Intel system] <sup>1</sup>
+ - [Dell WD19 Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-dock-wd19-90w-power-delivery-130w-ac/apd/210-ARIO/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/518) on an Intel system] <sup>1</sup>
  - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [[community-tested](https://github.com/system76/docs/pull/231) on an Intel system]
    - Requires extra configuration for suspend/resume to work.
+ - [Plugable UD-ULTCDL Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an Intel system] <sup>1</sup>
 
 ### For Intel systems
 

--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -70,6 +70,8 @@ Community members have reported that the following docks work with our products:
  - [Dell DS1000](https://www.dell.com/support/manuals/us/en/04/dell-dockstand-ds1000/ds1000_docking_stand_ug_publication/technical-specifications?guid=guid-1ad58fe1-dd33-4ebc-bac1-8e6a9083eb35&lang=en-us) [[community-tested](https://github.com/system76/docs/pull/431) on an Intel system]
    - Ethernet port not tested.
  - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/206) on an Intel system] <sup>1</sup>
+ - [Dell WD19 Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](#) on an Intel system] <sup>1</sup>
+ - [Plugable UD-ULTCDL Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](#) on an Intel system] <sup>1</sup>
  - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [[community-tested](https://github.com/system76/docs/pull/231) on an Intel system]
    - Requires extra configuration for suspend/resume to work.
 

--- a/_articles/use-docking-station.md
+++ b/_articles/use-docking-station.md
@@ -69,11 +69,12 @@ Community members have reported that the following docks work with our products:
    - Downstream (passthrough) Thunderbolt 3 port not tested.
  - [Dell DS1000](https://www.dell.com/support/manuals/us/en/04/dell-dockstand-ds1000/ds1000_docking_stand_ug_publication/technical-specifications?guid=guid-1ad58fe1-dd33-4ebc-bac1-8e6a9083eb35&lang=en-us) [[community-tested](https://github.com/system76/docs/pull/431) on an Intel system]
    - Ethernet port not tested.
+ - [Dell WD19 Dock](https://www.dell.com/en-us/work/shop/dell-dock-wd19-90w-power-delivery-130w-ac/apd/210-ARIO/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system] <sup>1</sup>
+   - Displays sometimes don't wake up from sleep until dock is re-plugged.
  - [Dell WD19TB Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-thunderbolt-dock-wd19tb/apd/210-arik/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/206) on an Intel system] <sup>1</sup>
- - [Dell WD19 Thunderbolt Dock](https://www.dell.com/en-us/work/shop/dell-dock-wd19-90w-power-delivery-130w-ac/apd/210-ARIO/pc-accessories) [[community-tested](https://github.com/system76/docs/pull/518) on an Intel system] <sup>1</sup>
  - [HP Thunderbolt Dock 120W G2](https://www.amazon.com/gp/product/B07DPKVYXR/ref=ppx_yo_dt_b_asin_title_o00_s01?ie=UTF8&psc=1) [[community-tested](https://github.com/system76/docs/pull/231) on an Intel system]
    - Requires extra configuration for suspend/resume to work.
- - [Plugable UD-ULTCDL Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an Intel system] <sup>1</sup>
+ - [Plugable UD-ULTCDL Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
  - [ThinkPad Thunderbolt 3 Workstation Dock Gen 2](https://www.lenovo.com/us/en/accessories-and-monitors/docking/universal-cable-docks-thunderbolt/TBT-WS-Dock-Gen-2/p/40ANY230US) [[community-tested](https://github.com/system76/docs/pull/517) on an Intel sytem] <sup>1</sup>
 
 ### For Intel systems


### PR DESCRIPTION
I use the Dell WD19 daily at work and the Plugable ud-ultcdl at home with great success. I'm using this with a brand new Gazelle (gaze15) laptop. Note: Just as it states on System76's website to use docks with this laptop you must have the GTX 1660 Ti.

I run the WD19 with three monitors plus the built in laptop display for a total of 4 displays. I so far have only tested the Plugable at home with a single monitor.

Power delivery does NOT work for either of these docks for the Gaze15 (I don't think the Gazelle can even charge via type-c but I may be wrong). My solution is just to leave an extra triple prong power cable for my laptop's power brick plugged in and ready to go next to where my laptop sits on my desk.

There are a couple issues with the WD19 (nothing a show stopper though):
- After you lock the computer and displays go to sleep sometimes one, two, or all three screens (usually it's just one but occasionally more) will fail to turn back on or will have really bad artifacts showing on screen. Unplug and then re-insert the cable back into the machine and everything goes back to normal (this isn't every time and happens about 5~10% of the time). Re-arranging the displays within the OS can also have this same problem.
- I have to leave the dock unplugged until I decrypt and fully login to the device. If the dock is plugged in when I try to decrypt the drive it will hang and unplugging the dock does nothing to fix this. You have to power cycle the laptop with the dock unplugged to decrypt. Same problem with first login after decrypt (logging out and in works fine though which is strange). This problem didn't pop up until I installed the displaylink drivers (but I need the displaylink drivers for the Plugable dock).

So far I haven't ran into any issues with the Plugable UD-ULTCDL but if I do I will make sure to update this thread.