### PR TITLE
Upgrade old releases: fix typos and add more release codewords to sed command

### DIFF
--- a/_articles/upgrade-pop.md
+++ b/_articles/upgrade-pop.md
@@ -95,7 +95,7 @@ Once restarted, the computer will be on the newly upgraded system! If you run in
 
 Upgrading Pop!\_OS 18.10, 19.04 or 19.10 will require upgrading to Pop!\_OS 20.04 LTS before upgrading to 20.10.
 
-These older Pop!\_OS releases are now unsupported and no new updates are available. After unsupported versions have been removed from the archive and mirror network, you will need to change where your system checks for un-applied updates to be able to upgrade. Open a terminal and follow the next set of instructions to upgrade from Pop!\_OS 18.10 or 19.04.
+These older Pop!\_OS releases are now unsupported and no new updates are available. After unsupported versions have been removed from the archive and mirror network, you will need to change where your system checks for un-applied updates to be able to upgrade. Open a terminal and follow the next set of instructions to upgrade from Pop!\_OS 18.10, 19.04, or 19.10.
 
 1) Get your current system fully updated:
 ```
@@ -114,21 +114,21 @@ sudo mv /etc/apt/sources.list.d/* /etc/apt/sources.list.d/backup
 sudo apt-add-repository -yn ppa:system76-dev/stable
 sudo apt-add-repository -yn ppa:system76/pop
 sudo sed -i 's/old-releases/us.archive/g' /etc/apt/sources.list
-sudo sed -i 's/disco/focal/g' /etc/apt/sources.list /etc/apt/sources.list.d/*.list
+sudo sed -Ei 's/cosmic|eoan|disco/focal/g' /etc/apt/sources.list /etc/apt/sources.list.d/*.list
 ```
 
-3) Now,do the upgrade! This will have a three phases and once the download is complete, you can't change your mind. This works from a new install of 19.04, but some packages may add complications, so make sure you have a backup of important data before moving forward. There may be a question about restarting services, and it is safe to answer "Yes". There may be some questions about using "maintainer" version of configuration files and using the that new version is also very likely what you want to do (and the default answer will work):
+3) Now, do the upgrade! This will have three phases, and once the download is complete, you can't change your mind. This works from a fresh installation, but some packages may add complications, so make sure you have a backup of important data before moving forward. There may be a question about restarting services, and it is safe to answer "Yes". There may be some questions about using the "maintainer's" version of configuration files, and using that new version is also very likely what you want to do (and the default answer will work):
 ```
 sudo apt update
 sudo apt install dpkg apt
 sudo apt full-upgrade | tee ~/upgrade.log
 ```
 
-4) Now put the PPAs back; You will want to take a look at the files that end in "list" in "/etc/apt/sources.list.d/backup" to see if you want to enable that again by moving them back to the /etc/apt/sources.list.d/ directory.
+4) Now put the PPAs back; you will want to take a look at the files that end in "list" in `/etc/apt/sources.list.d/backup` to see if you want to enable them again by moving them back to the `/etc/apt/sources.list.d/` directory.
 
 5) After the 20.04 Pop upgrade is complete, reboot.
 
-6) Run the command to upgrade to Pop 20.10
+6) Run the command to upgrade to Pop 20.10:
 ```
 pop-upgrade release upgrade
 ```


### PR DESCRIPTION
I noticed some typos in this article while linking it to someone this morning. This PR fixes the typos and minor grammar issues.

Also, since this section refers to 18.10, 19.04, and 19.10 in the first paragraph, I've made the rest of the section consistently refer to the same set of versions. This includes the `sed` command to replace the old codeword with the new codeword; `disco` would only work for 19.04, we need `cosmic` and `eoan` included in that command since the section is supposed to support 18.10 and 19.10. The new `E` option being added to the sed command [allows](https://unix.stackexchange.com/a/145404) using the `|` or operator so we can cover all three releases with one command instead of three commands.