### PR TITLE
Remove Pop version numbers from article

### DIFF
--- a/_articles/use-tensorman.md
+++ b/_articles/use-tensorman.md
@@ -16,7 +16,7 @@ section: software-applications
 
 # Using Tensorman
 
-<u>Tensorman</u> is a new tool for managing TensorFlow toolchains in Pop!_OS 19.10 (and coming soon to Pop!_OS 18.04 LTS). It can be installed with this command:
+<u>Tensorman</u> is a tool for managing TensorFlow toolchains in Pop!_OS. It can be installed with this command:
 
 ```
 sudo apt install tensorman


### PR DESCRIPTION
Tensorman is supported in the two currently-maintained releases, 20.04 LTS and 20.10. There is no longer a need to specify that it was new in version 19.10 (and it's confused some users in Mattermost, who read that sentence to mean it's not supported in newer releases.)