### PR TITLE
Remove stray slash from list of commands

### DIFF
--- a/_articles/pop-recovery.md
+++ b/_articles/pop-recovery.md
@@ -92,7 +92,6 @@ The EFI partition is usually around 512MB so that would be the partition that we
 sudo mount /dev/sda1 /mnt/boot/efi
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
 sudo cp -n /etc/resolv.conf /mnt/etc/
-/
 sudo chroot /mnt
 ```
 OR for NVMe drives:
@@ -101,7 +100,6 @@ OR for NVMe drives:
 sudo mount /dev/nvme0n1p1 /mnt/boot/efi
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
 sudo cp -n /etc/resolv.conf /mnt/etc/
-/
 sudo chroot /mnt
 ```
 


### PR DESCRIPTION
I was copying commands out of this article this morning and noticed there's a `/` in the middle of two command lists. It looks like these were added in https://github.com/system76/docs/pull/512 by mistake (as `/` is not a valid command, it was added to the Pop article but not the Ubuntu article, and that PR didn't say anything about why these lines were added.) The rest of the commands work normally without doing anything at this step.