### PR TITLE
howto on re-enabling raw image previews in nautilus.

### DIFF
--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -14,9 +14,9 @@ section: pop
 
 ---
 
-## Install Rawtherapee
+## Install RawTherapee
 
-Raw Therapee can handle a large array of RAW image formats. We will be using rawtherapee's ability export raw images into pngs for this howto.
+RawTherapee can handle a large array of RAW image formats. We will be using RawTherapee's ability export raw images into pngs for this howto.
 
 ```
 sudo apt install rawtherapee

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -39,15 +39,11 @@ Save the text file as `rawtherapee.thumbnailer`. We will move this new file into
 
 ## Moving to thumbnailer folder
 
-As with most files outside of your home directory you will need elevated privilages to move this file to the proper location.
+As with most files outside of your home directory, you will need elevated privilages to move this file to the proper location. Run the following command to move the thumbnailer file into place (replacing `<pathtofile>` with the actual path):
 
 ```
 sudo mv <pathtofile>/rawtherapee.thumbnailer /usr/share/thumbnailers
 ```
-
- Be sure to change <pathtofile> to the actual path.
-
-
 
 ## Clearing previous thumbnails
 

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -26,7 +26,7 @@ sudo apt install rawtherapee
 
 ## Create a custom thumbnailer
 
-Nautilus uses thumbnailer scripts to create the images. We will need to create one for our raw images. 
+Nautilus uses thumbnailer scripts to create thumbnails for images. We will need to create one for our raw images. Copy and paste the following text into your text editor of choice:
 
 ```
 [Thumbnailer Entry]
@@ -35,9 +35,7 @@ Exec=/usr/bin/rawtherapee-cli -s -n -Y -f -o %o -c %i
 MimeType=image/x-arw;image/x-bay;image/x-canon-cr2;image/x-canon-crw;image/x-cap;image/x-cr2;image/x-crw;image/x-dcr;image/x-dcraw;image/x-dcs;image/x-dng;image/x-drf;image/x-eip;image/x-erf;image/x-fff;image/x-fuji-raf;image/x-iiq;image/x-k25;image/x-kdc;image/x-mef;image/x-minolta-mrw;image/x-mos;image/x-mrw;image/x-nef;image/x-nikon-nef;image/x-nrw;image/x-olympus-orf;image/x-orf;image/x-panasonic-raw;image/x-panasonic-raw2;image/x-pef;image/x-pentax-pef;image/x-ptx;image/x-pxn;image/x-r3d;image/x-raf;image/x-raw;image/x-rw2;image/x-rwl;image/x-rwz;image/x-samsung-srw;image/x-sigma-x3f;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/x-sr2;image/x-srf;image/x-x3f;image/x-adobe-dng;image/x-portable-pixmap;image/tiff;
 ```
 
-Copy and paste the above text into your text editor of choice and save it as `rawtherapee.thumbnailer`. We will be moving this new file into the proper directory in the next step.
-
-
+Save the text file as `rawtherapee.thumbnailer`. We will move this new file into the proper directory in the next step.
 
 ## Moving to thumbnailer folder
 

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -2,7 +2,7 @@
 layout: article
 title: Fix raw image previews
 description: >
-   Add a custom thumbnail generator to display raw image formats in files.
+   Add a custom thumbnail generator to display thumbnails for raw image in Files.
 keywords:
   - Image Preview
   - Raw
@@ -16,7 +16,7 @@ section: pop
 
 ## Install RawTherapee
 
-RawTherapee can handle a large array of raw image formats. We can use RawTherapee's ability to convert raw images into pngs to create thumbnails for other programs.
+The Files app doesn't display thumbnails for raw images by default, but RawTherapee can handle a large array of raw image formats. We can use RawTherapee's ability to convert raw images into PNGs to create thumbnails for other programs.
 
 ```
 sudo apt install rawtherapee

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -51,7 +51,7 @@ Though sometimes unnessesary, it's always a good idea to start fresh with thumbn
 rm -r ~/.cache/thumbnails/*
 ```
 
-**Note:** If you have a lot of images, this will force Nautilus to recreate their thumbnails. Depending on the size of the files and their formats, this can cause some lag the first time visiting an image-heavy directory. 
+**Note:** This will force Nautilus to recreate the thumbnails for all of your files. Depending on the number, size, and format of your images, this can cause some lag the first time visiting an image-heavy directory. 
 
 ## Considerations
 

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -14,9 +14,11 @@ section: pop
 
 ---
 
+The Files app doesn't display thumbnails for raw images by default, but RawTherapee can handle a large array of raw image formats. We can use RawTherapee's ability to convert raw images into PNGs to create thumbnails for other programs.
+
 ## Install RawTherapee
 
-The Files app doesn't display thumbnails for raw images by default, but RawTherapee can handle a large array of raw image formats. We can use RawTherapee's ability to convert raw images into PNGs to create thumbnails for other programs.
+First, install RawTherapee using this command:
 
 ```
 sudo apt install rawtherapee

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -29,7 +29,7 @@ sudo apt install rawtherapee
 Nautilus uses thumbnailer scripts to generate thumbnails for images. Create a thumbnailer for raw images using this command:
 
 ```
-gedit admin:///usr/share/thumbnailers/rawtherapee.thumbnailer
+sudo gedit /usr/share/thumbnailers/rawtherapee.thumbnailer
 ```
 
 Copy and paste the following text into the file:

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -58,5 +58,4 @@ rm -r ~/.cache/thumbnails/*
 ## Considerations
 
 1. Not all raw images are supported by RawTherapee.
-
 2. Converting raw images to a more suitable format can take some time (~1 second per file in most cases.)

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -16,7 +16,7 @@ section: pop
 
 ## Install RawTherapee
 
-RawTherapee can handle a large array of raw image formats. We will be using RawTherapee's ability export raw images into pngs for this howto.
+RawTherapee can handle a large array of raw image formats. We can use RawTherapee's ability to convert raw images into pngs to create thumbnails for other programs.
 
 ```
 sudo apt install rawtherapee

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -26,7 +26,13 @@ sudo apt install rawtherapee
 
 ## Create a custom thumbnailer
 
-Nautilus uses thumbnailer scripts to create thumbnails for images. We will need to create one for our raw images. Copy and paste the following text into your text editor of choice:
+Nautilus uses thumbnailer scripts to create thumbnails for images. We will need to create one for our raw images. 
+
+```
+gedit admin:///usr/share/thumbnailers/rawtherapee.thumbnailer
+```
+
+Copy and paste the following text into the file:
 
 ```
 [Thumbnailer Entry]
@@ -35,15 +41,7 @@ Exec=/usr/bin/rawtherapee-cli -s -n -Y -f -o %o -c %i
 MimeType=image/x-arw;image/x-bay;image/x-canon-cr2;image/x-canon-crw;image/x-cap;image/x-cr2;image/x-crw;image/x-dcr;image/x-dcraw;image/x-dcs;image/x-dng;image/x-drf;image/x-eip;image/x-erf;image/x-fff;image/x-fuji-raf;image/x-iiq;image/x-k25;image/x-kdc;image/x-mef;image/x-minolta-mrw;image/x-mos;image/x-mrw;image/x-nef;image/x-nikon-nef;image/x-nrw;image/x-olympus-orf;image/x-orf;image/x-panasonic-raw;image/x-panasonic-raw2;image/x-pef;image/x-pentax-pef;image/x-ptx;image/x-pxn;image/x-r3d;image/x-raf;image/x-raw;image/x-rw2;image/x-rwl;image/x-rwz;image/x-samsung-srw;image/x-sigma-x3f;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/x-sr2;image/x-srf;image/x-x3f;image/x-adobe-dng;image/x-portable-pixmap;image/tiff;
 ```
 
-Save the text file as `rawtherapee.thumbnailer`. We will move this new file into the proper directory in the next step.
-
-## Moving to thumbnailer folder
-
-As with most files outside of your home directory, you will need elevated privilages to move this file to the proper location. Run the following command to move the thumbnailer file into place (replacing `<pathtofile>` with the actual path):
-
-```
-sudo mv <pathtofile>/rawtherapee.thumbnailer /usr/share/thumbnailers
-```
+Save the file and close Gedit.
 
 ## Clearing previous thumbnails
 

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -47,13 +47,13 @@ sudo mv <pathtofile>/rawtherapee.thumbnailer /usr/share/thumbnailers
 
 ## Clearing previous thumbnails
 
-Though sometimes unnessesary, it's always a good idea to start fresh with the thumbnail creation. To do this, we will delete the thumbnailer cache shown below.
+Though sometimes unnessesary, it's always a good idea to start fresh with the thumbnail creation. To do this, we will delete the thumbnailer cache using this command:
 
 ```
 rm -r ~/.cache/thumbnails/*
 ```
 
-**Note:** If you have a lot of images, this will force Nautilus to recreate their thumbnails. Depending on the size of the file and its format, this can cause some lag the first time visiting a image heavy directory. 
+**Note:** If you have a lot of images, this will force Nautilus to recreate their thumbnails. Depending on the size of the files and their formats, this can cause some lag the first time visiting an image-heavy directory. 
 
 ## Considerations
 

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -1,0 +1,70 @@
+---
+layout: article
+title: Howto fix raw image previews
+description: >
+   Add a custom thumbnail generator to display RAW image formats in files.
+keywords:
+  - Image Preview
+  - Raw
+  - Pop 20.04 LTS
+  - Thumbnails
+image: http://support.system76.com/images/system76.png
+hidden: false
+section: pop
+
+---
+
+## Install Rawtherapee
+
+Raw Therapee can handle a large array of RAW image formats. We will be using rawtherapee's ability export raw images into pngs for this howto.
+
+```
+sudo apt install rawtherapee
+```
+
+## Create a custom thumbnailer
+
+Nautilus uses thumbnailer scripts to create the images. We will need to create one for our RAW images. 
+
+```
+[Thumbnailer Entry]
+TryExec=/usr/bin/rawtherapee-cli
+Exec=/usr/bin/rawtherapee-cli -s -n -Y -f -o %o -c %i 
+MimeType=image/x-arw;image/x-bay;image/x-canon-cr2;image/x-canon-crw;image/x-cap;image/x-cr2;image/x-crw;image/x-dcr;image/x-dcraw;image/x-dcs;image/x-dng;image/x-drf;image/x-eip;image/x-erf;image/x-fff;image/x-fuji-raf;image/x-iiq;image/x-k25;image/x-kdc;image/x-mef;image/x-minolta-mrw;image/x-mos;image/x-mrw;image/x-nef;image/x-nikon-nef;image/x-nrw;image/x-olympus-orf;image/x-orf;image/x-panasonic-raw;image/x-panasonic-raw2;image/x-pef;image/x-pentax-pef;image/x-ptx;image/x-pxn;image/x-r3d;image/x-raf;image/x-raw;image/x-rw2;image/x-rwl;image/x-rwz;image/x-samsung-srw;image/x-sigma-x3f;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/x-sr2;image/x-srf;image/x-x3f;image/x-adobe-dng;image/x-portable-pixmap;image/tiff;
+```
+
+Copy and paste the above text into your text editor of choice and save it as `rawtherapee.thumbnailer`. We will be moving this new file into the proper directory in the next step.
+
+
+
+## Moving to thumbnailer folder
+
+As with most files outside of your home directory you will need elevated privilages to move this file to the proper location.
+
+```
+sudo mv <pathtofile>/rawtherapee.thumbnailer /usr/share/thumbnailers
+```
+
+ Be sure to change <pathtofile> to the actual path.
+
+
+
+## Clearing previous thumbnails
+
+Though sometimes unnessesary its always a good idea to start fresh with the thumbnail creation. To do this we will delete the thumbnailer cache shown below.
+
+
+
+```
+rm -r ~/.cache/thumbnails/*
+```
+
+**Note:** If you have a lot of images this will force Nautilus to recreate their thumbnail. Depending on the size of the file and its format this can cause some lag the first time visiting a image heavy directory. 
+
+
+
+## Considerations
+
+1.  Not all raw images are supported by RawTherapee
+
+2.  Converting raw images to a more suitable format can take some time. (~1 second per file in most cases)

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -2,7 +2,7 @@
 layout: article
 title: Fix raw image previews
 description: >
-   Add a custom thumbnail generator to display RAW image formats in files.
+   Add a custom thumbnail generator to display raw image formats in files.
 keywords:
   - Image Preview
   - Raw
@@ -16,7 +16,7 @@ section: pop
 
 ## Install RawTherapee
 
-RawTherapee can handle a large array of RAW image formats. We will be using RawTherapee's ability export raw images into pngs for this howto.
+RawTherapee can handle a large array of raw image formats. We will be using RawTherapee's ability export raw images into pngs for this howto.
 
 ```
 sudo apt install rawtherapee
@@ -24,7 +24,7 @@ sudo apt install rawtherapee
 
 ## Create a custom thumbnailer
 
-Nautilus uses thumbnailer scripts to create the images. We will need to create one for our RAW images. 
+Nautilus uses thumbnailer scripts to create the images. We will need to create one for our raw images. 
 
 ```
 [Thumbnailer Entry]

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -26,7 +26,7 @@ sudo apt install rawtherapee
 
 ## Create a custom thumbnailer
 
-Nautilus uses thumbnailer scripts to create thumbnails for images. We will need to create one for our raw images. 
+Nautilus uses thumbnailer scripts to generate thumbnails for images. Create a thumbnailer for raw images using this command:
 
 ```
 gedit admin:///usr/share/thumbnailers/rawtherapee.thumbnailer
@@ -41,11 +41,11 @@ Exec=/usr/bin/rawtherapee-cli -s -n -Y -f -o %o -c %i
 MimeType=image/x-arw;image/x-bay;image/x-canon-cr2;image/x-canon-crw;image/x-cap;image/x-cr2;image/x-crw;image/x-dcr;image/x-dcraw;image/x-dcs;image/x-dng;image/x-drf;image/x-eip;image/x-erf;image/x-fff;image/x-fuji-raf;image/x-iiq;image/x-k25;image/x-kdc;image/x-mef;image/x-minolta-mrw;image/x-mos;image/x-mrw;image/x-nef;image/x-nikon-nef;image/x-nrw;image/x-olympus-orf;image/x-orf;image/x-panasonic-raw;image/x-panasonic-raw2;image/x-pef;image/x-pentax-pef;image/x-ptx;image/x-pxn;image/x-r3d;image/x-raf;image/x-raw;image/x-rw2;image/x-rwl;image/x-rwz;image/x-samsung-srw;image/x-sigma-x3f;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/x-sr2;image/x-srf;image/x-x3f;image/x-adobe-dng;image/x-portable-pixmap;image/tiff;
 ```
 
-Save the file and close Gedit.
+Then save the file and close Gedit.
 
 ## Clearing previous thumbnails
 
-Though sometimes unnessesary, it's always a good idea to start fresh with the thumbnail creation. To do this, we will delete the thumbnailer cache using this command:
+Though sometimes unnessesary, it's always a good idea to start fresh with thumbnail creation. To do this, delete the thumbnailer cache using this command:
 
 ```
 rm -r ~/.cache/thumbnails/*

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -1,6 +1,6 @@
 ---
 layout: article
-title: Howto fix raw image previews
+title: Fix raw image previews
 description: >
    Add a custom thumbnail generator to display RAW image formats in files.
 keywords:

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -47,18 +47,16 @@ sudo mv <pathtofile>/rawtherapee.thumbnailer /usr/share/thumbnailers
 
 ## Clearing previous thumbnails
 
-Though sometimes unnessesary, it's always a good idea to start fresh with the thumbnail creation. To do this we will delete the thumbnailer cache shown below.
+Though sometimes unnessesary, it's always a good idea to start fresh with the thumbnail creation. To do this, we will delete the thumbnailer cache shown below.
 
 ```
 rm -r ~/.cache/thumbnails/*
 ```
 
-**Note:** If you have a lot of images this will force Nautilus to recreate their thumbnail. Depending on the size of the file and its format this can cause some lag the first time visiting a image heavy directory. 
-
-
+**Note:** If you have a lot of images, this will force Nautilus to recreate their thumbnails. Depending on the size of the file and its format, this can cause some lag the first time visiting a image heavy directory. 
 
 ## Considerations
 
-1.  Not all raw images are supported by RawTherapee
+1. Not all raw images are supported by RawTherapee.
 
-2.  Converting raw images to a more suitable format can take some time. (~1 second per file in most cases)
+2. Converting raw images to a more suitable format can take some time (~1 second per file in most cases.)

--- a/_articles/fix-raw-image-previews.md
+++ b/_articles/fix-raw-image-previews.md
@@ -47,9 +47,7 @@ sudo mv <pathtofile>/rawtherapee.thumbnailer /usr/share/thumbnailers
 
 ## Clearing previous thumbnails
 
-Though sometimes unnessesary its always a good idea to start fresh with the thumbnail creation. To do this we will delete the thumbnailer cache shown below.
-
-
+Though sometimes unnessesary, it's always a good idea to start fresh with the thumbnail creation. To do this we will delete the thumbnailer cache shown below.
 
 ```
 rm -r ~/.cache/thumbnails/*


### PR DESCRIPTION
This how-to is based on the work done in this issue [pop #1484](https://github.com/pop-os/pop/issues/1484) adding raw image thumbnails to work in 20.04 and 20.10. 
