### PR TITLE
fixes a broken link

### DIFF
--- a/_articles/laptop-battery-thresholds.md
+++ b/_articles/laptop-battery-thresholds.md
@@ -14,7 +14,7 @@ section: hardware-drivers
 
 Charging thresholds allow your System76 laptop to avoid charging the battery until it has dropped below a lower bound (the start threshold), and to stop charging when it reaches an upper bound (the end threshold). This is useful when your laptop is plugged into an AC power adapter for extended periods of time, as it prevents unnecessary micro-charging that would reduce battery longevity.
 
-To determine if your laptop has Open Firmware or proprietary firmware, see [this article](/articles/open-firmware-systems.md). (If a system has Open Firmware, then it must also have Open EC to work with charging thresholds.) See [Charging Thresholds](#configuring-charging-thresholds-open-firmware) for Open Firmware systems or [FlexiCharger](#configuring-flexicharger-proprietary-firmware) for proprietary firmware systems.
+To determine if your laptop has Open Firmware or proprietary firmware, see [this article](/articles/open-firmware-systems). (If a system has Open Firmware, then it must also have Open EC to work with charging thresholds.) See [Charging Thresholds](#configuring-charging-thresholds-open-firmware) for Open Firmware systems or [FlexiCharger](#configuring-flexicharger-proprietary-firmware) for proprietary firmware systems.
 
 ## Configuring Charging Thresholds (Open Firmware)
 


### PR DESCRIPTION
This fixed the link to the Open Firmware System list where it had a .md at the end of the link.