### PR TITLE
Fix typo "Text Editer" -> "Text Editor"

### DIFF
--- a/_articles/switch-from-macos-to-popos.md
+++ b/_articles/switch-from-macos-to-popos.md
@@ -515,7 +515,7 @@ LMMS, Ardour and Audacity are all available in the Pop!\_Shop.
 
 
 **Pop!\_OS**
-  - Text Editer (default)
+  - Text Editor (default)
   - [Atom](https://atom.io/) (available in the Pop!\_Shop)
   - [Microsoft VSCode](https://code.visualstudio.com/) (available in the Pop!\_Shop)
 


### PR DESCRIPTION
Hi System76 folks,

I spotted a very small typo while reading this page: https://support.system76.com/articles/switch-from-macos-to-popos/

I thought I would fix it while I'm at it. 😃 