### PR TITLE
Remove obsolete keyboard shortcuts

### DIFF
--- a/_articles/pop-keyboard-shortcuts.md
+++ b/_articles/pop-keyboard-shortcuts.md
@@ -50,14 +50,14 @@ Directional actions can use either the standard arrow keys or their Vim equivale
 
 #### Manipulate windows
 
-| Shortcut                                                   | Action                                     |
-| ---------------------------------------------------------- | ------------------------------------------ |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>S</kbd> | Toggle stacking                            |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>O</kbd> | Change window orientation (while stacking) |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>G</kbd> | Float/unfloat window (while stacking)      |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>M</kbd> | Maximize/unmaximize window                 |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Ctrl</kbd> + <kbd>←</kbd>/<kbd>→</kbd> | Snap window to left/right side of display |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Q</kbd> | Close window                               |
+| Shortcut                                                                                  | Action                                     |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------ |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>S</kbd>                                | Toggle stacking                            |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>O</kbd>                                | Change window orientation (while stacking) |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>G</kbd>                                | Float/unfloat window (while stacking)      |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>M</kbd>                                | Maximize/unmaximize window                 |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Ctrl</kbd> + <kbd>←</kbd>/<kbd>→</kbd> | Snap window to left/right side of display  |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Q</kbd>                                | Close window                               |
 
 #### Manage workspaces and displays
 

--- a/_articles/pop-keyboard-shortcuts.md
+++ b/_articles/pop-keyboard-shortcuts.md
@@ -1,7 +1,7 @@
 ---
 layout: article
 title: Pop!_OS Keyboard Shortcuts
-description: Learn how master using Pop!_OS with your keyboard
+description: Learn how master using Pop!_OS with your keyboard.
 keywords:
   - keyboard
   - shortcuts

--- a/_articles/pop-keyboard-shortcuts.md
+++ b/_articles/pop-keyboard-shortcuts.md
@@ -8,136 +8,107 @@ keywords:
 image: http://support.system76.com/images/system76.png
 hidden: false
 section: getting-started
-
 ---
 
-## Super Key
+## Notable Keys
 
-The Super Key is the OS key on your keyboard and is the Ubuntu or Pop key (<kbd><i class="fl-ubuntu"></i></kbd>, <kbd><span class="fl-pop-key"></span></kbd>).
+#### Super key
 
-In Pop!\_OS, <kbd><span class="fl-pop-key"></span></kbd> handles the majority of OS and window actions.
+The Super key is the OS key on your keyboard.
 
-### Pop!_OS (20.04 LTS and above) Shortcuts
+- On recent System76 products, it's the Pop key (<kbd><span class="fl-pop-key"></span></kbd>).
+- On older System76 products, it's the Ubuntu key (<kbd><i class="fl-ubuntu"></i></kbd>).
+- On generic third-party products, it may be labeled with a Windows logo.
+- On Mac accessories, it may be labeled `command`.
 
-To advance keyboard driven control, keyboard shortcuts have been modified in Pop!_OS 20.04.
-
-### Notable Shortcut Changes
-
-|          Action            |     Old Shortcut      |      New Shortcut  |
-|:---------------------------| :-------------------- |--------------------|
-Lock Screen                 | <kbd><span class="fl-pop-key"></span></kbd> + <kbd>L</kbd> | <kbd><span class="fl-pop-key"></span></kbd> + <kbd>ESC</kbd> |
-Move to Workspace Up or Down | <kbd><span class="fl-pop-key"></span></kbd> + <kbd>↑</kbd>/<kbd>↓</kbd> | <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Ctrl</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd> |
-Close Window                 | <kbd><span class="fl-pop-key"></span></kbd> + <kbd>W</kbd> | <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Q</kbd>
-Toggle Maximize              | <kbd><span class="fl-pop-key"></span></kbd> + <kbd>↑</kbd> | <kbd><span class="fl-pop-key"></span></kbd> + <kbd>M</kbd>
-
-
+In Pop!\_OS, the Super key handles the majority of OS and window actions. This key is represented by <kbd><span class="fl-pop-key"></span></kbd> in the lists below.
 
 #### Direction keys
 
-| Shortcut | Action |
-| -------- | ------ |
-| <kbd>←</kbd> + <kbd>↓</kbd> + <kbd>↑</kbd> + <kbd>→</kbd> | Direction keys (arrow keys) |
-| <kbd>H</kbd> + <kbd>J</kbd> + <kbd>K</kbd> + <kbd>L</kbd> | Direction keys (Vim shortcuts) |
+Directional actions can use either the standard arrow keys or their Vim equivalents:
 
-#### Move, resize and swap windows
+| Key                                                    | Description                    |
+| ------------------------------------------------------ | ------------------------------ |
+| <kbd>←</kbd>, <kbd>↓</kbd>, <kbd>↑</kbd>, <kbd>→</kbd> | Direction keys (arrow keys)    |
+| <kbd>H</kbd>, <kbd>J</kbd>, <kbd>K</kbd>, <kbd>L</kbd> | Direction keys (Vim shortcuts) |
 
-| Shortcut | Action |
-| -------- | ------ |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Enter</kbd> | Enter adjustment mode |
-| <kbd>Shift</kbd> + <kbd>Direction keys</kbd> | Resize window (while in adjustment mode) |
-| <kbd>Ctrl</kbd> + <kbd>Direction keys</kbd> | Swap windows (while in adjustment mode) |
-| <kbd>Enter</kbd> | Apply changes |
-| <kbd>ESC</kbd> | Cancel |
+## Keyboard Shortcuts
 
-#### Window Shortcuts
+#### Move, resize, and swap windows
 
-| Shortcut | Action |
-| -------- | ------ |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>O</kbd> | Change window orientation |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>G</kbd> | Toggle floating mode |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Q</kbd> | Close Window |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>M</kbd> | Toggle Maximize |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>S</kbd> | Toggle Stacking |
+| Shortcut                                                                | Action                                   |
+| ----------------------------------------------------------------------- | ---------------------------------------- |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Direction keys</kbd> | Switch focus between windows             |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Enter</kbd>          | Enter window adjustment mode             |
+| <kbd>Direction keys</kbd>                                               | Move window (while in adjustment mode)   |
+| <kbd>Shift</kbd> + <kbd>Direction keys</kbd>                            | Resize window (while in adjustment mode) |
+| <kbd>Ctrl</kbd> + <kbd>Direction keys</kbd>                             | Swap windows (while in adjustment mode)  |
+| <kbd>Enter</kbd>                                                        | Apply changes (exit adjustment mode)     |
+| <kbd>ESC</kbd>                                                          | Cancel (exit adjustment mode)            |
+| <kbd><span class="fl-pop-key"></span></kbd> + Left click + Drag         | Move window (without adjustment mode)    |
+| <kbd><span class="fl-pop-key"></span></kbd> + Right cick + Drag         | Resize window (without adjustment mode)  |
 
-#### Navigate applications and windows
+#### Manipulate windows
 
-| Shortcut | Action |
-| -------- | ------ |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>/</kbd> | Launch and switch applications |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Direction keys</kbd> | Switch focus between windows |
+| Shortcut                                                   | Action                                     |
+| ---------------------------------------------------------- | ------------------------------------------ |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>S</kbd> | Toggle stacking                            |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>O</kbd> | Change window orientation (while stacking) |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>G</kbd> | Float/unfloat window (while stacking)      |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>M</kbd> | Maximize/unmaximize window                 |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Ctrl</kbd> + <kbd>←</kbd>/<kbd>→</kbd> | Snap window to left/right side of display |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Q</kbd> | Close window                               |
 
-#### Workspaces
+#### Manage workspaces and displays
 
-| Shortcut | Action |
-| -------- | ------ |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Ctrl</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd> | Move to Workspace Up or Down |
+| Shortcut                                                                                   | Action                                         |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Ctrl</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd>  | Navigate between workspaces                    |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Home</kbd>/<kbd>End</kbd>               | Navigate to first/last workspace               |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Shift</kbd> + <kbd>Direction keys</kbd> | Move active window between workspaces/displays |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>ESC</kbd>                               | Lock the screen                                |
 
-#### Launcher Shortcuts
+#### Use the launcher
 
-| Shortcut | Action |
-| -------- | ------ |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>/</kbd> | Activate Launcher |
-| <kbd>t:</kbd> | Execute a command in a terminal |
-| <kbd>:</kbd> | Execute a command in sh |
-| <kbd>=</kbd> | Calculate an equation |
+The launcher allows searching through open windows and installed applications, and also has the additional functions listed below.
 
-### Pop!_OS (up to 19.10 release) Shortcuts
+| Shortcut/command                                           | Action                          |
+| ---------------------------------------------------------- | ------------------------------- |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>/</kbd> | Activate the launcher           |
+| `d:`                                                       | Browse and search recent files  |
+| `/` or `~`                                                 | Browse the filesystem           |
+| `t:`                                                       | Execute a command in a terminal |
+| `:`                                                        | Execute a command in sh         |
+| `=`                                                        | Calculate an equation           |
 
-#### Primary Actions
+#### Switch between apps and windows
 
-Tapping <kbd><span class="fl-pop-key"></span></kbd> on its own brings up the **Activities overview**, which is the core way of launching apps and managing your workflow.
+| Shortcut                                                                        | Action                                         |
+| ------------------------------------------------------------------------------- | ---------------------------------------------- |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Tab</kbd>                    | Switch apps                                    |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Tab</kbd> + <kbd>Shift</kbd> | Switch apps in reverse order                   |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>`</kbd>                      | Switch windows of current app                  |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>`</kbd> + <kbd>Shift</kbd>   | Switch windows of current app in reverse order |
 
-<kbd><span class="fl-pop-key"></span></kbd> + <kbd>↑</kbd>/<kbd>↓</kbd> switch workspaces up and down.  
-<kbd>Ctrl</kbd> + <kbd><span class="fl-pop-key"></span></kbd> + <kbd>←</kbd>/<kbd>→</kbd> tile windows to the left and right of your display.  
-<kbd><span class="fl-pop-key"></span></kbd> + <kbd>Tab</kbd> quickly switches between your open windows.  
+#### Miscellaneous OS shortcuts
 
-## All Shortcuts
+| Shortcut                                                       | Action                                             |
+| -------------------------------------------------------------- | -------------------------------------------------- |
+| <kbd><span class="fl-pop-key"></span></kbd>                    | Toggle Activities overview                         |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>A</kbd>     | Toggle applications menu                           |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>V</kbd>     | Toggle notifications menu                          |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>T</kbd>     | Open a terminal                                    |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>F</kbd>     | Open Files                                         |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>P</kbd>     | Cycle display layout                               |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Space</kbd> | Cycle between configured input sources (languages) |
+| <kbd>Alt</kbd> + <kbd>F2</kbd>                                 | Run command                                        |
+| <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Del</kbd>              | Log out                                            |
 
-#### Window & Workspace Management
+#### Accessibility shortcuts
 
-Windows can be switched between, moved around, tiled, and closed all with the keyboard. <kbd>Shift</kbd> acts as a modifier that lets you do a variation on the action, too.
+| Shortcut                                                                                 | Action                                  |
+| ---------------------------------------------------------------------------------------- | --------------------------------------- |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Alt</kbd> + <kbd>S</kbd>              | Toggle screen reader                    |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Alt</kbd> + <kbd>8</kbd>              | Toggle magnifier                        |
+| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Alt</kbd> + <kbd>+</kbd>/<kbd>-</kbd> | Zoom in/out (when magnifier is enabled) |
 
-| Shortcut | Action  | <kbd>Shift</kbd> Action |
-| -------- | --------- | ------ |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Tab</kbd> | Switch windows | Switch windows backwards |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>`</kbd> | Switch windows of current app | Switch windows of current app backwards |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>W</kbd> | Close window | |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>H</kbd> | Hide window (minimize) | |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>↑</kbd>/<kbd>↓</kbd> | Switch workspace up/down | Switch workspace up/down with window |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Home</kbd>/<kbd>End</kbd> | Switch to first/last workspace | Switch to first/last workspace with window |
-| <kbd>Ctrl</kbd> + <kbd><span class="fl-pop-key"></span></kbd> + <kbd>←</kbd>/<kbd>→</kbd> | Tile window to the left/right | |
-| <kbd>Ctrl</kbd> + <kbd><span class="fl-pop-key"></span></kbd> + <kbd>↑</kbd> | Toggle maximize | |
-| <kbd>Ctrl</kbd> + <kbd><span class="fl-pop-key"></span></kbd> + <kbd>↓</kbd> | Restore window (unmaximize/untile) | |
-| <kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd><span class="fl-pop-key"></span></kbd> + <kbd>←</kbd>/<kbd>→</kbd>/<kbd>↑</kbd>/<kbd>↓</kbd> | Move window to display to the left, right, top, or bottom | |
-| <kbd><span class="fl-pop-key"></span></kbd> + Drag | Move window | |
-| <kbd><span class="fl-pop-key"></span></kbd> + Right-drag | Resize window | |
-| <kbd>Alt</kbd> + <kbd>Space</kbd> | Window menu |
-
-#### Operating System
-
-| Shortcut | Action |
-| -------- | ------ |
-| <kbd><span class="fl-pop-key"></span></kbd> | Activities overview |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>A</kbd> | Applications |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>P</kbd> | Presentation mode (cycle display modes) |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>L</kbd> | Lock screen |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>O</kbd> | Orientation lock (on devices w/accelerometer) |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>D</kbd> | Show desktop |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>V</kbd> | Calendar and notifications indicator |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>N</kbd> | Focus active notification |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>T</kbd> | Terminal |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>F</kbd> | Files |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>M</kbd> | Application menu |
-| <kbd><span class="fl-pop-key"></span></kbd> + <kbd>Space</kbd> | Switch input source |
-| <kbd>Alt</kbd> + <kbd>F2</kbd> | Run command |
-| <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Del</kbd> | Log out |
-
-#### Accessibility
-
-Accessibility shortcuts use <kbd>Alt</kbd> + <kbd><span class="fl-pop-key"></span></kbd> as their base.
-
-| Shortcut | Action |
-| -------- | ------ |
-| <kbd>Alt</kbd> + <kbd><span class="fl-pop-key"></span></kbd> + <kbd>S</kbd> | Toggle screen reader |
-| <kbd>Alt</kbd> + <kbd><span class="fl-pop-key"></span></kbd> + <kbd>8</kbd> | Toggle magnifier |
-| <kbd>Alt</kbd> + <kbd><span class="fl-pop-key"></span></kbd> + <kbd>+</kbd>/<kbd>-</kbd> | Zoom in/out (when magnifier is active) |

--- a/_articles/ubuntu-keyboard-shortcuts.md
+++ b/_articles/ubuntu-keyboard-shortcuts.md
@@ -1,7 +1,7 @@
 ---
 layout: article
 title: Ubuntu Keyboard Shortcuts
-description: Learn how master using Ubuntu with your keyboard
+description: Learn how master using Ubuntu with your keyboard.
 keywords:
   - keyboard
   - shortcuts


### PR DESCRIPTION
Closes #454.

As the current supported releases of Pop!_OS are 20.04 LTS and 20.10, and the current keyboard shortcut scheme is no longer new, the notes and entire sections referring to older versions of Pop are no longer needed (and have started creating confusion, in at least #454 and https://github.com/system76/docs/issues/396.) This PR removes all shortcuts that no longer work in the current releases, and moves the remaining shortcuts into more appropriate categories where possible.