### PR TITLE
Fixed link for oryp4

### DIFF
--- a/_articles/guides.md
+++ b/_articles/guides.md
@@ -99,7 +99,7 @@ To see ports, keyboard layouts, function keys, and product quickstart guides, fi
 | Oryx |
 | -----|
 | [orxp1](/images/guides/orxp1.pdf) | [oryp2](/images/guides/oryp2.png) | [oryp3-15](/images/guides/oryp3-15.png) |
-| [oryp3-17](/images/guides/oryp3-17.png) | [oryp4](https://system76.com/guides/oryp4) | [oryp5-16](/images/guides/oryp5-16.png) | 
+| [oryp3-17](/images/guides/oryp3-17.png) | [oryp4](/images/guides/oryp4.png) | [oryp5-16](/images/guides/oryp5-16.png) | 
 | [oryp5-17](/images/guides/oryp5-17.png) | [oryp6](https://tech-docs.system76.com/models/oryp6/README.html) | [oryp7](https://tech-docs.system76.com/models/oryp7/README.html) |
 
 | Pangolin |


### PR DESCRIPTION
Fixed the link for oryp4 to go to the correct file and avoid a redirect issue.