### PR TITLE
Update dead link for Pop!_OS's Roadmap article

### DIFF
--- a/_articles/difference-between-pop-ubuntu.md
+++ b/_articles/difference-between-pop-ubuntu.md
@@ -25,7 +25,7 @@ Pop!_OS has evolved quite a bit since its 17.10 release. While the easiest way t
 
 This is a common question to come up, and one that makes our engineers cringe. Yes, Pop!_OS has been designed with vibrant colors, a flat theme, and a clean desktop environment, but we created it to do so much more than just look pretty. (Although it does look very pretty.)
 
-To call it a re-skinned Ubuntu brushes over all of the features and quality-of-life improvements that Pop! developers work diligently to create. For an in-depth look at the effort and manpower that goes into updating and maintaining Pop!_OS, take a look at our [Roadmap](https://pop.system76.com/docs/roadmap/) documentation and the [This Week in Pop!](https://pop-planet.info/forums/forums/project-updates.28/) series on [Pop!_Planet](https://pop-planet.info/). Below, you’ll find a general list of improvements that make Pop!_OS stand out.
+To call it a re-skinned Ubuntu brushes over all of the features and quality-of-life improvements that Pop! developers work diligently to create. For an in-depth look at the effort and manpower that goes into updating and maintaining Pop!_OS, take a look at our [Roadmap](https://support.system76.com/articles/roadmap/) documentation and the [This Week in Pop!](https://pop-planet.info/forums/forums/project-updates.28/) series on [Pop!_Planet](https://pop-planet.info/). Below, you’ll find a general list of improvements that make Pop!_OS stand out.
 
 <br>
 ## First impressions: The Installer 


### PR DESCRIPTION
It seems the link has changed but was not updated in the process. I think that the link leading to "This Week in Pop!" should also be updated or removed since this doesn't seem to be active anymore.