### PR TITLE
Add jekyll-redirect-from plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll-last-modified-at', group: :jekyll_plugins
+gem 'jekyll-redirect-from', group: :jekyll_plugins


### PR DESCRIPTION
This should enable the `redirect_from` blocks found in some of the pages front matter. 