### PR TITLE
Update Ubuntu 20.04 Download Link to Fix 404 Error

### DIFF
--- a/_articles/live-disk.md
+++ b/_articles/live-disk.md
@@ -46,7 +46,7 @@ A live disk is a handy tool to have around!
 
 ### For Ubuntu/Pop!_OS
 
-In order to install Pop!_OS or Ubuntu, we must first download the .iso image. This is a disk image with the operating system and installer on it. You can [download Pop!_OS here](http://pop.system76.com) or [Ubuntu 20.04 here](https://www.ubuntu.com/download/desktop/thank-you?version=20.04.1&architecture=amd64).
+In order to install Pop!_OS or Ubuntu, we must first download the .iso image. This is a disk image with the operating system and installer on it. You can [download Pop!_OS here](http://pop.system76.com) or [Ubuntu 20.04 here](https://ubuntu.com/download/desktop/thank-you?version=20.04.2.0&architecture=amd64).
 
 In order to make a live disk of Pop!_OS you must have a bootable flash drive. You'll need a flash drive, of course, and software to write the Pop!_OS .iso image to the drive. There's a variety of applications you can use to write disk images to a flash drive, but for this tutorial we'll use the Disks applicaton for Ubuntu and Etcher for Windows/MacOS.
 


### PR DESCRIPTION
Updated the link to the Ubuntu 20.04 download, as the original link would load a download page, which would then redirect into a 404.

This new link goes to the download page, then presents the user with the download of the ISO file.