### PR TITLE
Add Fedora commands

### DIFF
--- a/_articles/system76-driver.md
+++ b/_articles/system76-driver.md
@@ -69,6 +69,16 @@ cd system76-driver
 makepkg -srcif
 sudo systemctl enable --now system76
 ```
+
+#### Fedora
+Run these commands in a <u>Terminal</u> to enable the [community Fedora COPR](https://copr.fedorainfracloud.org/coprs/szydell/system76/) and install the <u>System76 Driver</u> :
+
+```bash
+sudo dnf copr enable szydell/system76
+sudo dnf install system76-driver
+```
+
+
 #### Installing the System76 NVIDIA Driver for Systems with NVIDIA GPUs 
 
 If your system has an NVIDIA graphics card, you will want to go ahead and use this command to install the System76 Driver with NVIDIA graphics drivers built-in:


### PR DESCRIPTION
Added commands for installing the system76-driver on Fedora, using the community-maintained repository [here](https://copr.fedorainfracloud.org/coprs/szydell/system76/)
Will add full instructions on installing all system76 packages in a different article.