### PR TITLE
Update system76 driver arch

### DIFF
--- a/_articles/system76-driver.md
+++ b/_articles/system76-driver.md
@@ -56,6 +56,16 @@ sudo apt install system76-driver
 
 This installs the System76 driver and related utilities which are needed to enable full functionality for your system. 
 
+#### Installing the System76 NVIDIA Driver for Systems with NVIDIA GPUs 
+
+If your system has an NVIDIA graphics card, you will want to go ahead and use this command to install the System76 Driver with NVIDIA graphics drivers built-in:
+
+```
+sudo apt-get install system76-driver-nvidia
+```
+
+In addition to the standard packages, that will pull in the latest NVIDIA drivers as packaged by System76, and all related packages needed to take full advantage of your dedicated NVIDIA graphics card.
+
 ### Install System76 Driver on Other OSes
 
 #### Arch
@@ -68,13 +78,6 @@ git clone https://aur.archlinux.org/system76-driver.git
 cd system76-driver
 makepkg -srcif
 sudo systemctl enable --now system76
-```
-#### Installing the System76 NVIDIA Driver for Systems with NVIDIA GPUs 
+``` 
 
-If your system has an NVIDIA graphics card, you will want to go ahead and use this command to install the System76 Driver with NVIDIA graphics drivers built-in:
-
-```
-sudo apt-get install system76-driver-nvidia
-```
-
-In addition to the standard packages, that will pull in the latest NVIDIA drivers as packaged by System76, and all related packages needed to take full advantage of your dedicated NVIDIA graphics card. 
+NOTE: For other featues like keyboard backlight support and firmware updates other packages will need to be installed.

--- a/_articles/system76-driver.md
+++ b/_articles/system76-driver.md
@@ -80,4 +80,4 @@ makepkg -srcif
 sudo systemctl enable --now system76
 ``` 
 
-NOTE: For other featues like keyboard backlight support and firmware updates other packages will need to be installed.
+NOTE: For other featues like keyboard backlight support and firmware updates other packages will need to be installed. Refer to this [article](/articles/system76-software) to install that software.

--- a/_articles/system76-driver.md
+++ b/_articles/system76-driver.md
@@ -2,7 +2,7 @@
 layout: article
 title: Install the System76 Driver
 description: >
-    Learn how to add the System76 Driver to your System76 computer after reinstalling your OS
+    Learn how to add the System76 Driver to your System76 computer after reinstalling Ubuntu
 keywords:
   - system76
   - driver
@@ -56,6 +56,42 @@ sudo apt install system76-driver
 
 This installs the System76 driver and related utilities which are needed to enable full functionality for your system. 
 
+### Install System76 Driver on Other OSes
+
+#### Arch
+
+First let's install some packages needed for the build process of the <u>System76 Firmware Daemon</u> and the <u>System76 Driver</u>:
+
+```bash
+sudo pacman -S --needed base-devel git linux-headers
+```
+
+Run these commands in a <u>Terminal</u> to clone, build and install the <u>System76 Firmware Daemon</u>:
+
+```bash
+git clone https://aur.archlinux.org/system76-firmware.git
+makepkg -srcif
+sudo systemctl enable --now system76-firmware-daemon
+```
+
+Now the <u>System76 Driver</u> can be cloned, built and installed using these commands:
+
+```bash
+git clone https://aur.archlinux.org/system76-driver.git
+cd system76-driver
+makepkg -srcif
+sudo systemctl enable --now system76
+```
+
+#### Fedora
+Run these commands in a <u>Terminal</u> to enable the [community Fedora COPR](https://copr.fedorainfracloud.org/coprs/szydell/system76/) and install the <u>System76 Driver</u> :
+
+```bash
+sudo dnf copr enable szydell/system76
+sudo dnf install system76-driver
+```
+
+
 #### Installing the System76 NVIDIA Driver for Systems with NVIDIA GPUs 
 
 If your system has an NVIDIA graphics card, you will want to go ahead and use this command to install the System76 Driver with NVIDIA graphics drivers built-in:
@@ -64,20 +100,4 @@ If your system has an NVIDIA graphics card, you will want to go ahead and use th
 sudo apt-get install system76-driver-nvidia
 ```
 
-In addition to the standard packages, that will pull in the latest NVIDIA drivers as packaged by System76, and all related packages needed to take full advantage of your dedicated NVIDIA graphics card.
-
-### Install System76 Driver on Other OSes
-
-#### Arch
-
-Run these commands in a <u>Terminal</u> to clone, build and install the <u>System76 Driver</u> :
-
-```bash
-sudo pacman -S --needed base-devel git linux-headers
-git clone https://aur.archlinux.org/system76-driver.git
-cd system76-driver
-makepkg -srcif
-sudo systemctl enable --now system76
-``` 
-
-NOTE: For other featues like keyboard backlight support and firmware updates other packages will need to be installed. Refer to this [article](/articles/system76-software) to install that software.
+In addition to the standard packages, that will pull in the latest NVIDIA drivers as packaged by System76, and all related packages needed to take full advantage of your dedicated NVIDIA graphics card. 

--- a/_articles/system76-driver.md
+++ b/_articles/system76-driver.md
@@ -2,7 +2,7 @@
 layout: article
 title: Install the System76 Driver
 description: >
-    Learn how to add the System76 Driver to your System76 computer after reinstalling Ubuntu
+    Learn how to add the System76 Driver to your System76 computer after reinstalling your OS
 keywords:
   - system76
   - driver

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -12,3 +12,33 @@ section: hardware-drivers
 
 ---
 
+## Arch
+
+Be sure to install the <u>System76 Driver</u> first and the steps to do that are [here](/articles/system76-driver). 
+
+### System76 Firmware CLI
+
+```bash
+git clone https://aur.archlinux.org/system76-firmware.git
+cd system76-firmware-daemon
+makepkg -srcif
+sudo systemctl enable --now system76-firmware-daemon
+```
+
+### System76 Firmware Manager
+
+```bash
+git clone https://aur.archlinux.org/firmware-manager.git
+cd firmware-manager
+makepkg -srcif
+```
+
+### System76 DKMS
+
+This package is needed for the keyboard backlight key combos to work and the system will need to be rebooted for it to work:
+
+```bash
+git clone https://aur.archlinux.org/system76-dkms.git
+cd system76-dkms
+makepkg -srcif
+```

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -16,7 +16,7 @@ section: hardware-drivers
 
 Be sure to install the <u>System76 Driver</u> first and the steps to do that are [here](/articles/system76-driver). 
 
-### System76 Firmware CLI
+### System76 Firmware Daemon
 
 ```bash
 git clone https://aur.archlinux.org/system76-firmware.git
@@ -98,10 +98,14 @@ NOTE: This package is only needed for systems with OLED displays to control the 
 
 Be sure to install the <u>System76 Driver</u> first and the steps to do that are [here](/articles/system76-driver). Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u> then enable the service:
 
+### System76 Firmware Manager and Daemon
+
 ```bash
 sudo dnf install system76-driver system76-firmware firmware-manager
 sudo systemctl start system76-firmware-daemon
 ```
+
+### System76 Power
 
 Use these commands to install the <u>System76 Power</u> package and enable the service:
 
@@ -110,8 +114,34 @@ sudo systemctl enable system76-power system76-power-wake
 sudo systemctl start system76-power
 ```
 
-This command will be used to install the <u>System76 DKMS</u> and <u>System76 ACPI DKMS</u> packages:
+### System76 DKMS
+
+This command will be used to install the <u>System76 DKMS</u> package which is for Non Open Firmware systems:
 
 ```bash
-sudo dnf install system76-dkms system76-acpi-dkms
+sudo dnf install system76-dkms
+```
+
+### System76 ACPI DKMS
+
+This command will be used to install the <u>System76 ACPI DKMS<u> package which is for Open Firmware systems:
+
+```bash
+sudo dnf install system76-acpi-dkms
+```
+
+### System76 Thelio Io DKMS
+
+This command will be used to install the <u>System76 Io DKMS</u> which is used for the Thelio Io board:
+
+```bash
+sudo dnf install system76-io-dkms
+```
+
+### System76 OLED
+
+This command will be used to install the <u>System76 OLED</u> which is used for systems with OLED panels:
+
+```bash
+sudo dnf install system76-oled
 ```

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -100,10 +100,12 @@ Be sure to install the <u>System76 Driver</u> first and the steps to do that are
 
 ### System76 Firmware Manager
 
-Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u> then enable the service:
+Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u>,enable the service and add your user to the adm group:
 
 ```bash
 sudo dnf install firmware-manager
+sudo systemctl enable --now system76-firmware-daemon
+sudo gpasswd -a $USER adm
 ```
 
 ### System76 Power

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -11,3 +11,4 @@ hidden: false
 section: hardware-drivers
 
 ---
+

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -12,6 +12,10 @@ section: hardware-drivers
 
 ---
 
+# Notes about these instructions
+
+They were tested on a Galago Pro (galp3-b) and a Pangolin (pang10) and both systems do not have NVIDIA GPU's so this process doesn't go over installing the NVIDIA Driver. Due to this your system may not have working switchable graphics.
+
 ## Arch
 
 Be sure to install the <u>System76 Driver</u> first and the steps to do that are [here](/articles/system76-driver). 

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -96,9 +96,11 @@ NOTE: This package is only needed for systems with OLED displays to control the 
 
 ## Fedora
 
-Be sure to install the <u>System76 Driver</u> first and the steps to do that are [here](/articles/system76-driver). Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u> then enable the service:
+Be sure to install the <u>System76 Driver</u> first and the steps to do that are [here](/articles/system76-driver). 
 
 ### System76 Firmware Manager and Daemon
+
+Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u> then enable the service:
 
 ```bash
 sudo dnf install system76-driver system76-firmware firmware-manager

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -93,3 +93,25 @@ makepkg -srcif
 ```
 
 NOTE: This package is only needed for systems with OLED displays to control the brightness.
+
+## Fedora
+
+Be sure to install the <u>System76 Driver</u> first and the steps to do that are [here](/articles/system76-driver). Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u> then enable the service:
+
+```bash
+sudo dnf install system76-driver system76-firmware firmware-manager
+sudo systemctl start system76-firmware-daemon
+```
+
+Use these commands to install the <u>System76 Power</u> package and enable the service:
+
+```bash
+sudo systemctl enable system76-power system76-power-wake 
+sudo systemctl start system76-power
+```
+
+This command will be used to install the <u>System76 DKMS</u> and <u>System76 ACPI DKMS</u> packages:
+
+```bash
+sudo dnf install system76-dkms system76-acpi-dkms
+```

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -36,7 +36,7 @@ makepkg -srcif
 
 ### System76 DKMS
 
-This package is needed for the keyboard backlight key combos to work on Closed Firmware systems:
+This package is needed for hotkeys and fan(s) on Closed Firmware systems:
 
 ```bash
 git clone https://aur.archlinux.org/system76-dkms.git
@@ -46,7 +46,7 @@ makepkg -srcif
 
 ### System76 ACPI DKMS
 
-This package is needed for the keyboard backlight key combos to work on Open Firmware systems:
+This package is needed for hotkeys and fan(s) on Open Firmware systems:
 
 ```bash
 git clone https://aur.archlinux.org/system76-acpi-dkms.git
@@ -92,4 +92,4 @@ cd system76-acpi-oled
 makepkg -srcif
 ```
 
-NOTE: This package is only needed for systems with OLED displays.
+NOTE: This package is only needed for systems with OLED displays to control the brightness.

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -1,0 +1,13 @@
+---
+layout: article
+title: Install System76 Software to fully use the hardware in other OSes
+description: >
+    Learn what software is needed to use other OSes and install them
+keywords:
+  - system76
+  - support
+image: http://support.system76.com/images/system76.png
+hidden: false
+section: hardware-drivers
+
+---

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -18,7 +18,7 @@ They were tested on a Galago Pro (galp3-b) and a Pangolin (pang10) and both syst
 
 ## Arch
 
-Be sure to install the <u>System76 Driver</u> first and the steps to do that are [here](/articles/system76-driver). 
+Be sure to install the <u>System76 Driver</u> first. The steps to do that are [here](/articles/system76-driver). 
 
 ### System76 Firmware Daemon
 

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -103,7 +103,7 @@ Be sure to install the <u>System76 Driver</u> first and the steps to do that are
 Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u> then enable the service:
 
 ```bash
-sudo dnf installfirmware-manager
+sudo dnf install firmware-manager
 ```
 
 ### System76 Power

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -14,7 +14,7 @@ section: hardware-drivers
 
 # Notes about these instructions
 
-They were tested on a Galago Pro (galp3-b) and a Pangolin (pang10) and both systems do not have NVIDIA GPU's so this process doesn't go over installing the NVIDIA Driver. Due to this your system may not have working switchable graphics.
+NOTE: These instructions were tested on a Galago Pro (galp3-b) and Pangolin (pang10). Neither system have NVIDIA GPUs, so this process doesn't go over installing the NVIDIA driver (system76-driver-nvidia). Due to these limitations, switchable graphics may not work on NVIDIA systems.
 
 ## Arch
 

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -98,13 +98,12 @@ NOTE: This package is only needed for systems with OLED displays to control the 
 
 Be sure to install the <u>System76 Driver</u> first and the steps to do that are [here](/articles/system76-driver). 
 
-### System76 Firmware Manager and Daemon
+### System76 Firmware Manager
 
 Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u> then enable the service:
 
 ```bash
-sudo dnf install system76-driver system76-firmware firmware-manager
-sudo systemctl start system76-firmware-daemon
+sudo dnf installfirmware-manager
 ```
 
 ### System76 Power

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -116,7 +116,7 @@ sudo systemctl start system76-power
 
 ### System76 DKMS
 
-This command will be used to install the <u>System76 DKMS</u> package which is for Non Open Firmware systems:
+This command will be used to install the <u>System76 DKMS</u> package which is for Proprietary Firmware systems:
 
 ```bash
 sudo dnf install system76-dkms

--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -1,6 +1,6 @@
 ---
 layout: article
-title: Install System76 Software to fully use the hardware in other OSes
+title: Install System76 Software in other OSes
 description: >
     Learn what software is needed to use other OSes and install them
 keywords:
@@ -23,6 +23,7 @@ git clone https://aur.archlinux.org/system76-firmware.git
 cd system76-firmware-daemon
 makepkg -srcif
 sudo systemctl enable --now system76-firmware-daemon
+sudo gpasswd -a $USER adm
 ```
 
 ### System76 Firmware Manager
@@ -35,10 +36,60 @@ makepkg -srcif
 
 ### System76 DKMS
 
-This package is needed for the keyboard backlight key combos to work and the system will need to be rebooted for it to work:
+This package is needed for the keyboard backlight key combos to work on Closed Firmware systems:
 
 ```bash
 git clone https://aur.archlinux.org/system76-dkms.git
 cd system76-dkms
 makepkg -srcif
 ```
+
+### System76 ACPI DKMS
+
+This package is needed for the keyboard backlight key combos to work on Open Firmware systems:
+
+```bash
+git clone https://aur.archlinux.org/system76-acpi-dkms.git
+cd system76-acpi-dkms
+makepkg -srcif
+```
+
+### System76 Power
+
+```bash
+git clone https://aur.archlinux.org/system76-power.git
+cd system76-power
+makepkg -srcif
+sudo systemctl enable --now system76-power
+sudo gpasswd -a $USER adm
+```
+
+#### System76 Power GNOME Shell Extension
+
+```bash
+git clone https://aur.archlinux.org/gnome-shell-extension-system76-power-git.git
+cd gnome-shell-extension-system76-power
+makepkg -srcif
+```
+
+NOTE: As of this writing the GNOME Shell Extension doesn't support GNOME 40.
+
+### System76 Thelio Io DKMS
+
+```bash
+git clone https://aur.archlinux.org/system76-io-dkms.git
+cd system76-io-dkms
+makepkg -srcif
+```
+
+NOTE: This package is only needed for Thelio desktops.
+
+### System76 OLED 
+
+```bash
+git clone https://aur.archlinux.org/system76-oled.git
+cd system76-acpi-oled
+makepkg -srcif
+```
+
+NOTE: This package is only needed for systems with OLED displays.


### PR DESCRIPTION
This adds a new article for installing our software on Fedora and Arch, it also updates the System76 Driver article to install the firmware daemon before the System76 Driver.