### PR TITLE
add dkms enable command for Fedora

### DIFF
--- a/_articles/system76-software.md
+++ b/_articles/system76-software.md
@@ -127,6 +127,7 @@ This command will be used to install the <u>System76 DKMS</u> package which is f
 
 ```bash
 sudo dnf install system76-dkms
+sudo systemctl enable dkms
 ```
 
 ### System76 ACPI DKMS
@@ -135,6 +136,13 @@ This command will be used to install the <u>System76 ACPI DKMS<u> package which 
 
 ```bash
 sudo dnf install system76-acpi-dkms
+sudo systemctl enable dkms
+```
+
+NOTE: After enabling the dkms systemd service for either the <u>System76 DKMS</u> or the <u>System76 ACPI DKMS</u> package you will need to reboot the system:
+
+```bash
+sudo systemctl reboot
 ```
 
 ### System76 Thelio Io DKMS


### PR DESCRIPTION
This allows the keyboard backlights to be controlled on Fedora on our systems.