### PR TITLE
fix absolute urls in content files

### DIFF
--- a/content/before-you-open-a-support-ticket.md
+++ b/content/before-you-open-a-support-ticket.md
@@ -34,7 +34,7 @@ The first message sent on a ticket does not support file attachments; however, t
 
 If you're having difficulty attaching a file, you can also email the file to info@system76.com. Please be sure to tell us on the ticket if you have sent an email attachment.
 
-If you encounter problems signing into your account, or opening a ticket, please [follow these steps](https://support.system76.com/articles/clear-cache-and-cookies/)
+If you encounter problems signing into your account, or opening a ticket, please [follow these steps](/articles/clear-cache-and-cookies)
 
 ## Before We Begin:
 
@@ -42,13 +42,13 @@ If you encounter problems signing into your account, or opening a ticket, please
 
 Depending on how time sensitive your issue is, the fastest resolution may be to reinstall the operating system. Re-imaging is much easier to do if we know that your important files are safe.
 
-We have a help article on backing up your system [here](https://support.system76.com/articles/backup-files/)
+We have a help article on backing up your system [here](/articles/backup-files)
 
 ### 2. Do you have a Live USB drive with a copy of either Ubuntu or PopOS available in case we need to use it as a rescue disk?
 
 This will provide us an outside OS environment to access your installed system, potentially rescue files that have not been backed up, or quickly reinstall the OS if necessary.
 
-We have a help article on creating [Live USBs here](https://support.system76.com/articles/live-disk/)
+We have a help article on creating [Live USBs here](/articles/live-disk)
 
 # Common Issue Sources
 
@@ -58,9 +58,9 @@ We have a help article on creating [Live USBs here](https://support.system76.com
 
 We have help articles on the Recovery Partition and how to access the Boot Menu listed below.
 
-[Recovery Partition](https://support.system76.com/articles/pop-recovery/)
+[Recovery Partition](/articles/pop-recovery)
 
-[Boot Menu](https://support.system76.com/articles/boot-menu/)
+[Boot Menu](/articles/boot-menu)
 
 
 ### 4. Is your system fully up to date?
@@ -92,7 +92,7 @@ sudo apt full-upgrade
 reboot
 ```
 
-Source: [Fix Package Manager](https://support.system76.com/articles/package-manager-pop/)
+Source: [Fix Package Manager](/articles/package-manager-pop)
 
 ### 5. Have you tried creating an administrative Test User account to see if the issue is present in a different user?
 
@@ -105,15 +105,15 @@ That can be done by:
 - Make sure click the **Administrator** option for the user.
 - Reboot and log into the new user.
 
-[Creating User Accounts](https://support.system76.com/articles/other-accounts/)
+[Creating User Accounts](/articles/other-accounts)
 
 ### 6. Is there a new OS version available?
 Upgrading to the latest OS version usually includes newer kernel modules and software packages, as well as security updates and bug-fixes.
 These updates may directly or indirectly resolve your issue.
 
-[Upgrade Pop](https://support.system76.com/articles/upgrade-pop/)
+[Upgrade Pop](/articles/upgrade-pop)
 
-[Upgrade Ubuntu](https://support.system76.com/articles/upgrade-ubuntu/)
+[Upgrade Ubuntu](/articles/upgrade-ubuntu)
 
 ### 7. Have you tried reinstalling the packages or programs that are giving you trouble?
 
@@ -143,9 +143,9 @@ Where "<packagename>" is replaced with the program name, without angle-brackets.
 
 You can also inspect and edit your software sources using the instructions in these help articles:
 
-[Manage Repositories in Pop!\_OS](https://support.system76.com/articles/manage-repos-pop/)
+[Manage Repositories in Pop!\_OS](/articles/manage-repos-pop)
 
-[Manage Repositories in Ubuntu](https://support.system76.com/articles/manage-repos-ubuntu/)
+[Manage Repositories in Ubuntu](/articles/manage-repos-ubuntu)
 
 
 ### 8. Let’s collect some system logs to get more information on what’s happening with your system.
@@ -155,7 +155,7 @@ To generate the logs we need, please click on **Activities** in the top left of 
 
 Then click on the **Create Log Files** button and the log file will be in your home directory when you first open the Files application.
 
-For more information, please see this support article: [Creating Log Files](https://support.system76.com/articles/log-files/)
+For more information, please see this support article: [Creating Log Files](/articles/log-files)
 
 ## Environment
 
@@ -176,7 +176,7 @@ For more information, please see this support article: [Creating Log Files](http
 
 ### 15. If this is a hardware issue, steps 3 and 5 will help confirm it.
 
-We also have an article on diagnosing hardware failures which can be found [here](https://support.system76.com/articles/hardware-failure/)
+We also have an article on diagnosing hardware failures which can be found [here](/articles/hardware-failure)
 
 We have several repair or replacement options available depending on the circumstances.
 
@@ -184,7 +184,7 @@ We have several repair or replacement options available depending on the circums
 We build and ship a replacement system with the same configuration, and have you return the defective system once the new one is received. More details will be provided if this process is requested.
 
 ### Advance Replacement Part - Within Warranty Period
-We send a replacement part for self-service or service at a local repair shop, then have you return the defective part. We also provide the service manual for your machine if applicable. You can see the available [service manuals here](https://support.system76.com/articles/service-manuals/) and [here](https://tech-docs.system76.com/)
+We send a replacement part for self-service or service at a local repair shop, then have you return the defective part. We also provide the service manual for your machine if applicable. You can see the available [service manuals here](/articles/service-manuals) and [here](https://tech-docs.system76.com/)
 
 More details will be provided if this process is requested.
 

--- a/content/bluetooth.md
+++ b/content/bluetooth.md
@@ -15,7 +15,7 @@ section: network-troubleshooting
 
 # Important Notes About Bluetooth
 
-Bluetooth is a bit odd. 
+Bluetooth is a bit odd.
 There are a lot of factors that go into whether Bluetooth devices work together as expected.
 
 
@@ -54,26 +54,26 @@ Sometimes Bluetooth devices are working correctly, but something in settings nee
 
 The easiest way to test this is to "forget" the paired Bluetooth device, and pair it again.
 
-A more thorough way of testing this would be to create a [test user](https://support.system76.com/articles/other-accounts/), or boot from a [Live Disk](https://support.system76.com/articles/live-disk/) to see if Bluetooth works in either case. 
-If it does, config files may need deleted. If it doesn't (especially in the Live Disk), reinstalling the OS may solve the problem. 
+A more thorough way of testing this would be to create a [test user](/articles/other-accounts), or boot from a [Live Disk](/articles/live-disk) to see if Bluetooth works in either case. 
+If it does, config files may need deleted. If it doesn't (especially in the Live Disk), reinstalling the OS may solve the problem.
 Reinstalling the OS won't affect Bluetooth hardware directly, but resetting and starting with a clean slate can solve a slew of problems and save time hunting for a specific file or bug.
 
 
 # Setting Expectations
 
-Because of all of these factors, if the steps outlined in the Bluetooth troubleshooting article, and the previous troubleshooting steps don't resolve the issue, the issue may not be resolved at all. 
+Because of all of these factors, if the steps outlined in the Bluetooth troubleshooting article, and the previous troubleshooting steps don't resolve the issue, the issue may not be resolved at all.
 Or, in a future update or change to the system, the devices may start working again. In some cases (many cases) users will not experience any issue with Bluetooth at all.
 
 ## Audio Input/Output
 
 Bluetooth audio devices, such as headphones and speakers, usually default to the A2DP protocol, which works effectively as an audio output source.
 
-Bluetooth devices with microphones built in, can be used if the device supports HFP/HSP. However, without the technology that companies like Sony have patented, the solution is to divide up the audio stream so that some of it is used for audio out and some for audio in. 
+Bluetooth devices with microphones built in, can be used if the device supports HFP/HSP. However, without the technology that companies like Sony have patented, the solution is to divide up the audio stream so that some of it is used for audio out and some for audio in.
 This process lowers the sound quality of the stream when in HSP/HFP mode, so audio may be "tinny," compressed (lower-fidelity), or at a lower volume. That is expected behavior.
 
 ---
 
-# Bluetooth Troubleshooting 
+# Bluetooth Troubleshooting
 
 
 Bluetooth issues can be troubleshooted in several ways.  The first thing to check is toggling airplane mode which will sometimes get Bluetooth functioning again.  Next, make sure Bluetooth is enabled in the top bar, or in the <u>Bluetooth</u> system settings.

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -112,4 +112,4 @@ sudo apt update
 
 *These packages have been tested with the System76 NVIDIA driver only.
 
-The following [article](https://support.system76.com/articles/system76-driver/) will go over installing the System76 NVIDIA driver.
+The following [article](/articles/system76-driver) will go over installing the System76 NVIDIA driver.

--- a/content/difference-between-pop-ubuntu.md
+++ b/content/difference-between-pop-ubuntu.md
@@ -25,10 +25,10 @@ Pop!_OS has evolved quite a bit since its 17.10 release. While the easiest way t
 
 This is a common question to come up, and one that makes our engineers cringe. Yes, Pop!_OS has been designed with vibrant colors, a flat theme, and a clean desktop environment, but we created it to do so much more than just look pretty. (Although it does look very pretty.)
 
-To call it a re-skinned Ubuntu brushes over all of the features and quality-of-life improvements that Pop! developers work diligently to create. For an in-depth look at the effort and manpower that goes into updating and maintaining Pop!_OS, take a look at our [Roadmap](https://support.system76.com/articles/roadmap/) documentation and the [This Week in Pop!](https://pop-planet.info/forums/forums/project-updates.28/) series on [Pop!_Planet](https://pop-planet.info/). Below, you’ll find a general list of improvements that make Pop!_OS stand out.
+To call it a re-skinned Ubuntu brushes over all of the features and quality-of-life improvements that Pop! developers work diligently to create. For an in-depth look at the effort and manpower that goes into updating and maintaining Pop!_OS, take a look at our [Roadmap](/articles/roadmap) documentation and the [This Week in Pop!](https://pop-planet.info/forums/forums/project-updates.28/) series on [Pop!_Planet](https://pop-planet.info/). Below, you’ll find a general list of improvements that make Pop!_OS stand out.
 
 <br>
-## First impressions: The Installer 
+## First impressions: The Installer
 
 ![Installer Images: Download screen](/images/difference-between-pop-ubuntu/Installer-Screenshot.png)
 
@@ -54,21 +54,21 @@ After conducting a study of Ubuntu and GNOME keyboard shortcuts, we decided to m
 [See all keyboard shortcuts](/articles/pop-keyboard-shortcuts/)
 
 <br>
-## Default Apps: Slimming down on bloatware 
+## Default Apps: Slimming down on bloatware
 
 ![Pop Shop](/images/difference-between-pop-ubuntu/Pop!_Shop-Screenshot.png)
 
 Pop!_OS includes a selection of apps intended to be comprehensive, but relatively lightweight. Because Pop!_OS is optimized for your workflow, we avoid providing some larger programs by default that slow down your computer. This is especially true for library applications, such as one for storing your photos, which we opt to replace with image viewers or similar apps that are smaller in size. However, if you’re in need of a photo manager, Steam, or a music streaming app such as Spotify, these applications are still available in the Pop!_Shop for a quick install.
 
 <br>
-## Features across the board 
+## Features across the board
 
 ![Power Profiles/Graphics toggle](/images/difference-between-pop-ubuntu/system-menu.png)
 
-Pop!_OS is built from Ubuntu repositories, meaning you get the same access to software as Ubuntu. Based on both user feedback and in-house testing, we continue to make changes and updates to the operating system for quality-of-life improvements. The best part is, updates are kept on a rolling release cycle, so you don’t have to wait around 6 months for bug fixes or improvements to your OS. While our [Roadmap](https://support.system76.com/articles/roadmap/) offers a more extensive outline of these changes, we’ve highlighted some of our major improvements below:
+Pop!_OS is built from Ubuntu repositories, meaning you get the same access to software as Ubuntu. Based on both user feedback and in-house testing, we continue to make changes and updates to the operating system for quality-of-life improvements. The best part is, updates are kept on a rolling release cycle, so you don’t have to wait around 6 months for bug fixes or improvements to your OS. While our [Roadmap](/articles/roadmap) offers a more extensive outline of these changes, we’ve highlighted some of our major improvements below:
  * Vulkan drivers and libraries are installed by default to get the most out of your GPU’s performance. Selecting the NVIDIA version of Pop!_OS on install also downloads the NVIDIA drivers by default.
  * The power profile picker in the top right menu easily toggles between high performance, balanced, and battery saver modes. On the Oryx Pro, this is also where you’ll find the toggle for switching graphics between Intel and NVIDIA. While these features have been developed specifically for System76 products, they may likely still work on your hardware.
- * For scientific workloads, installing [CUDA](https://support.system76.com/articles/cuda/) and [TensorFlow](https://support.system76.com/articles/install-tensorflow/) is made simple with a single command line.
+ * For scientific workloads, installing [CUDA](/articles/cuda) and [TensorFlow](/articles/install-tensorflow) is made simple with a single command line.
 	![CUDA/Tensorflow command](/images/difference-between-pop-ubuntu/Tensorflow.png)
  * Do Not Disturb mode silences notifications to help you focus on your work.
  * systemd-boot bootloader and the automatic configuration tool we’ve created for it called kernelstub replace the outdated GRUB bootloader used on Ubuntu. The systemd-boot bootloader is faster and smaller in size, increasing your computer’s startup speed.

--- a/content/disaster-recovery.md
+++ b/content/disaster-recovery.md
@@ -15,7 +15,7 @@ section: software-troubleshooting
 
 # Disaster Data Recovery
 
-This article covers ways to extract and save your data in the event of an OS failure, update failure, or similar situation. If you are having issues reaching your login screen, this [article](https://support.system76.com/articles/login-loop-pop/) may be helpful instead.
+This article covers ways to extract and save your data in the event of an OS failure, update failure, or similar situation. If you are having issues reaching your login screen, this [article](/articles/login-loop-pop) may be helpful instead.
 ## If you can't boot your installed OS
 
 If you are not able to boot into your installed OS, then we will want to boot from a live disk. If you have Pop!\_OS installed we can use the Pop!\_OS Recovery Partition.
@@ -30,7 +30,7 @@ We do not need to chroot into the installed OS to back up data, only mount the O
 
 ![Top Left Menu](/images/disaster-recovery/Dialog.png)
 
-Use the top-right menu (as shown above) to connect to your Wi-Fi once booted into the live disk. 
+Use the top-right menu (as shown above) to connect to your Wi-Fi once booted into the live disk.
 
 ### Mount the installed OS
 
@@ -39,7 +39,7 @@ Then copy and paste the encryption commands (if the OS is encrypted) and the mou
 
 > **NOTE:** If you own System76 hardware and/or have a System76 Account, this will also allow you to access Support Tickets, copy/paste commands from those tickets or upload log files, etc.
 
-## Software 
+## Software
 
 Once the drive is mounted, we can install software to back up files.
 ### Deja Dup
@@ -48,7 +48,7 @@ Once the drive is mounted, we can install software to back up files.
 
 ### Rsync
 
-[rsync](https://www.digitalocean.com/community/tutorials/how-to-use-rsync-to-sync-local-and-remote-directories) is a popular command-line tool to copy data while keeping the permissions. It is useful if the system is powering down or if you want a command-line tool to copy the files. 
+[rsync](https://www.digitalocean.com/community/tutorials/how-to-use-rsync-to-sync-local-and-remote-directories) is a popular command-line tool to copy data while keeping the permissions. It is useful if the system is powering down or if you want a command-line tool to copy the files.
 
 ```bash
 rsync -avxP \
@@ -82,7 +82,7 @@ On the **Storage location** page, you can configure the location where your back
 
 ## Hardware
 
-An external or internal drive can be used as a local backup location. 
+An external or internal drive can be used as a local backup location.
 
 ### External
 
@@ -93,12 +93,12 @@ The specs below offer an idea on what to look for when purchasing external stora
 
 ### Internal
 
-If your system included a second drive beside the OS drive, we have this [article](/articles/extra-drive/) that goes over setting up the drive to auto-mount once the OS is either repaired or reinstalled. 
+If your system included a second drive beside the OS drive, we have this [article](/articles/extra-drive/) that goes over setting up the drive to auto-mount once the OS is either repaired or reinstalled.
 If we have the installed OS mounted in the live disk open the <u>Files</u> application then go to ***Other Locations*** to access the secondary drive. Unless you've changed the name of your drive, System76 systems ship with secondary drives labelled "Extra Drive" or "Extra Drive #."
 
 #### Restoring Your Data
 
-Once we have our data backed up we can reinstall the OS. This [article](https://support.system76.com/articles/install-pop/) goes over the usual install process whether you're intalling from Recovery or a Live Disk:
+Once we have our data backed up we can reinstall the OS. This [article](/articles/install-pop) goes over the usual install process whether you're intalling from Recovery or a Live Disk:
 
 Now that we reinstalled the OS we can start restoring our data. To restore your data with Deja Dup, select the **Overview** page, then click the **Restore...** button. This will allow you to select the location containing the Deja Dup backup folder, and will copy the data from the most recent backup to its original location.
 
@@ -115,7 +115,7 @@ If signs are pointing to the drive itself being the issue, and your files are co
 
 # Future Steps
 
-Now that we have our data, and a clean install of the OS, let's prepare for if this issue happens again. It's good practice to set up scheduled backups. Our [backup article](/articles/backup-files) can help. 
+Now that we have our data, and a clean install of the OS, let's prepare for if this issue happens again. It's good practice to set up scheduled backups. Our [backup article](/articles/backup-files) can help.
 
 > **NOTE** Good practice to prevent data loss is to ensure that any important files are backed up in at least three (3) places. Two (2) copies on-site, and one (1) copy off-site. This off-site backup could be through a cloud storage solution, or a drive that's kept at a relative's house, or in a safety deposit box.
 

--- a/content/dual-booting.md
+++ b/content/dual-booting.md
@@ -335,7 +335,7 @@ Depending on how you installed Windows and which firmware your computer is runni
 
 ### Repairing the Pop!_OS Bootloader
 
-If Pop!_OS stops booting or no longer appears as a boot option after the Windows installation, or after a Windows update, see [this article](https://support.system76.com/articles/bootloader/) for information on repairing the Pop!_OS bootloader.
+If Pop!_OS stops booting or no longer appears as a boot option after the Windows installation, or after a Windows update, see [this article](/articles/bootloader) for information on repairing the Pop!_OS bootloader.
 
 ### Fixing the System Clock
 

--- a/content/hardware-failure.md
+++ b/content/hardware-failure.md
@@ -19,7 +19,7 @@ section: hardware-troubleshooting
 
 If a computer won't turn on, this could be any number of component failures.  The only way to know for sure which one has failed, is to test the system without anything attached.  We need to disconnect anything that can be removed.  This includes: the hard drives, Wifi card, RAM, and video cards (desktop, with on-board graphics).
 
-The only thing the system needs to boot is one stick of RAM in slot 0. Try different RAM sticks in slot 0 if it doesn't boot (to test for failed RAM).  Also, remove the CMOS battery and disconnect the main battery (laptops), and any AC input, for one minute.  We don't recommend removing the CPU as a test. The following key combo may also be handled at boot time to reset the CMOS as well <kbd>Fn</kbd>+<kbd>D</kbd>. 
+The only thing the system needs to boot is one stick of RAM in slot 0. Try different RAM sticks in slot 0 if it doesn't boot (to test for failed RAM).  Also, remove the CMOS battery and disconnect the main battery (laptops), and any AC input, for one minute.  We don't recommend removing the CPU as a test. The following key combo may also be handled at boot time to reset the CMOS as well <kbd>Fn</kbd>+<kbd>D</kbd>.
 
 If the system will boot with everything removed, then add components back one by one and see which one is causing the problem.  If everything works fine after removing and replacing all of the hardware, a loose connection is most likely the culprit.  If the system won't boot with everything disconnected, then the motherboard has likely failed, and needs replacing.
 
@@ -73,13 +73,13 @@ There are a few tools that we can use to confirm whether there is an issue with 
 There is a free download link for Linux on the home page and once that is pressed the download will start. There should be a `Unigine_Heaven-4.0.run` file in the Downloads directory and from a terminal let's run this command:
 
 ```bash
-chmod +x Unigine_Heaven-4.0.run 
+chmod +x Unigine_Heaven-4.0.run
 ```
 
 Then the application can be extracted:
 
 ```bash
-./Unigine_Heaven-4.0.run 
+./Unigine_Heaven-4.0.run
 ```
 
 Then let's move to the new directory that was created:
@@ -149,4 +149,4 @@ If there is no log or the log is empty, then the crash isn't related to a hardwa
 
 #### Support
 
-Please contact [support](https://support.system76.com/) by opening a ticket to get the system repaired or to have failed components replaced.
+Please contact [support](/) by opening a ticket to get the system repaired or to have failed components replaced.

--- a/content/install-tensorflow.md
+++ b/content/install-tensorflow.md
@@ -15,7 +15,7 @@ section: software
 
 # Tensorman
 
-If your system is running Pop!_OS 19.10, see the [Tensorman documentation](/articles/use-tensorman/) for managing TensorFlow containers.
+If your system is running Pop!_OS 19.10, see the [Tensorman documentation](/articles/use-tensorman) for managing TensorFlow containers.
 
 ## Install on Pop!_OS 20.04 LTS and Pop!_OS 20.10
 
@@ -30,7 +30,7 @@ sudo apt install tensorflow-cuda-latest
 This will install the following packages:
 
 ```bash
-system76-cuda-10.2 system76-cudnn-10.2 
+system76-cuda-10.2 system76-cudnn-10.2
 ```
 
 When the package with '-latest' is installed then when a new version if packaged and released an update will be available. When the system is updated these packages will be updated as well.
@@ -57,8 +57,8 @@ sudo apt update
 
 *These packages have been tested with the System76 NVIDIA driver only.
 
-The following [article](https://support.system76.com/articles/system76-driver/) will go over installing the System76 NVIDIA driver.
+The following [article](/articles/system76-driver) will go over installing the System76 NVIDIA driver.
 
 ## Using TensorFlow
 
-The following [article](https://support.system76.com/articles/use-tensorflow/) will go over using TensorFlow.
+The following [article](/articles/use-tensorflow) will go over using TensorFlow.

--- a/content/open-firmware-smmstore.md
+++ b/content/open-firmware-smmstore.md
@@ -40,7 +40,7 @@ calling Schedule method failed: "failed to add boot entry: exit code: 5
 system76-firmware: failed to schedule: failed to add boot entry: exit code: 5
 ```
 
-we may need to clear the SMMSTORE ROM by flashing new firmware using a flash drive with a custom firmware update tool. Here are the steps to perform that action. After flashing, this will remove any custom EFI variables (such as those installed by boot managers). We have information on repairing the bootloader at the end of this article. 
+we may need to clear the SMMSTORE ROM by flashing new firmware using a flash drive with a custom firmware update tool. Here are the steps to perform that action. After flashing, this will remove any custom EFI variables (such as those installed by boot managers). We have information on repairing the bootloader at the end of this article.
 
 Please download the zip file for your sytem and unzip the files within to a FAT32 formatted USB drive. Then shutdown the laptop and remove all NVMe M.2 drive(s) in the system using the step by step instructions for your system:
 
@@ -59,8 +59,8 @@ With all drive(s) removed, replace the cover and boot with the USB stick inserte
 
 Once the system is put back together we may need to boot with a live image in order to repair the boot loader if you dual-boot with Windows 10. We provide step by step instructions on how to do this in our support articles in the links below:
 
-[http://support.system76.com/articles/live-disk/](http://support.system76.com/articles/live-disk/)
+[https://support.system76.com/articles/live-disk/](/articles/live-disk)
 
-[https://support.system76.com/articles/bootloader/](https://support.system76.com/articles/bootloader/)
+[https://support.system76.com/articles/bootloader/](/articles/bootloader)
 
-If at any point you run into any errors during this process please paste / attach photos of the errors in a support ticket. 
+If at any point you run into any errors during this process please paste / attach photos of the errors in a support ticket.

--- a/content/pop-recovery.md
+++ b/content/pop-recovery.md
@@ -21,7 +21,7 @@ section: software-troubleshooting
 
 The recovery partition on this operating system is a full copy of the Pop!\_OS installation disk. It can be used exactly the same as if a live disk copy of Pop!\_OS was booted from a USB drive. The existing operating system can be repaired or reinstalled from the recovery mode. You can also perform a refresh install, which allows you to reinstall without losing any user data or data in your home directory, or opt to do a fresh install, which will essentially reset all OS data. Refresh Installs are only available on a fresh install of Pop!\_OS 19.04 and above.
 
-To boot into recovery mode, bring up the <u>systemd-boot</u> menu by holding down <kbd>SPACE</kbd> while the system is booting, or by holding/tapping any function keys **NOT** used to [Access the BIOS/Boot Menu](https://support.system76.com/articles/boot-menu/) (On non-System76 hardware, try the keys <kbd>F1</kbd> through <kbd>F12</kbd>) 
+To boot into recovery mode, bring up the <u>systemd-boot</u> menu by holding down <kbd>SPACE</kbd> while the system is booting, or by holding/tapping any function keys **NOT** used to [Access the BIOS/Boot Menu](/articles/boot-menu) (On non-System76 hardware, try the keys <kbd>F1</kbd> through <kbd>F12</kbd>) 
 
 > **NOTE:** These instructions assume Pop!\_OS is the only OS running on your system. If you are booting more than one operating system you may need to change your boot order first, or manually select the Pop!\_OS Disk from your BIOS/Boot menu.
 
@@ -86,12 +86,12 @@ The EFI partition is usually around 512MB so that would be the partition that we
 | ```sudo mount /dev/sda1 /mnt/boot/efi```                                 | ```sudo mount /dev/nvme0n1p1 /mnt/boot/efi```                            |
 
 ```bash
-for i in dev dev/pts proc sys run; do sudo mount -B $i /mnt/$i; done 
+for i in dev dev/pts proc sys run; do sudo mount -B $i /mnt/$i; done
 sudo cp -n /etc/resolv.conf /mnt/etc/
 sudo chroot /mnt
 ```
 
-With this last command you will have root access to your installed system. You can also access your files with <u>files</u> via "Other Locations" > Computer > /mnt. 
+With this last command you will have root access to your installed system. You can also access your files with <u>files</u> via "Other Locations" > Computer > /mnt.
 
 ### After Chroot
 

--- a/content/power-on-failure-desktop.md
+++ b/content/power-on-failure-desktop.md
@@ -14,24 +14,24 @@ section: hardware-troubleshooting
 
 # General Troubleshooting
 
-1. Check that the power cable is connected securely at the computer input and the electrical outlet 
-  * 1a. Confirm the surge protector is turned on if that applies 
-  * 1b. Confirm that the power strip is turned on if that applies 
-  * 1c. Turn the surge protector off and on again 
+1. Check that the power cable is connected securely at the computer input and the electrical outlet
+  * 1a. Confirm the surge protector is turned on if that applies
+  * 1b. Confirm that the power strip is turned on if that applies
+  * 1c. Turn the surge protector off and on again
 
-2. Confirm the outlet works by plugging in another device. 
-3. Be sure that the system is on a flat surface 
+2. Confirm the outlet works by plugging in another device.
+3. Be sure that the system is on a flat surface
 4. Desktops have a button on the power supply located at the back of the computer. Toggle that button and make sure it is in the 'On' position though it may be labeled as a '1' to note that it is powered on, then attempt to turn the desktop on.
-5. If the power button lights up, the power supply is providing power to the machine. It is recommended to check the display connections next. 
-  * 5a. If the display connections are not at fault, investigate internal components using steps outlined in this [article](https://support.system76.com/articles/hardware-failure/). 
+5. If the power button lights up, the power supply is providing power to the machine. It is recommended to check the display connections next.
+  * 5a. If the display connections are not at fault, investigate internal components using steps outlined in this [article](/articles/hardware-failure). 
 6. If the power button does not light up, the computer may need a new power button or power supply. To troubleshoot the power button on a Thelio desktop, visit this [link](https://tech-docs.system76.com/models/thelio-massive-b1.2/repairs.html#troubleshooting-the-power-button).
-7. Does the computer turn on when using the power switch on the Thelio IO board instead of the button? The backup power button is located on the IO board near the power button on the internal part of the case. 
+7. Does the computer turn on when using the power switch on the Thelio IO board instead of the button? The backup power button is located on the IO board near the power button on the internal part of the case.
 
 ![Thelio Io power button](/images/failure-power-on/thelio-io-power-button.png)
 
-Instructions to remove the top case and access this button can be found here: 
+Instructions to remove the top case and access this button can be found here:
 
-- [Thelio Mira](https://tech-docs.system76.com/models/thelio-mira-r1.0/repairs.html#troubleshooting-the-power-button) 
+- [Thelio Mira](https://tech-docs.system76.com/models/thelio-mira-r1.0/repairs.html#troubleshooting-the-power-button)
 - [Thelio Mega](https://tech-docs.system76.com/models/thelio-mega-r1.0/repairs.html#troubleshooting-the-power-button)
 - [Thelio R1/R2 - Page 15](https://github.com/system76/docs/blob/gh-pages/service-manuals/pdfs/Thelio/R1/thelio-r1-service-manual.pdf)
 - [Thelio B1/B2 - Page 15](https://github.com/system76/docs/blob/gh-pages/service-manuals/pdfs/Thelio/B1/thelio-b1-service-manual.pdf)

--- a/content/power-on-failure-laptop.md
+++ b/content/power-on-failure-laptop.md
@@ -16,11 +16,10 @@ section: hardware-troubleshooting
 1. Is the laptop operating on battery power when it fails to power on? If the laptop does not power on when running on battery power, but is turning on when plugged in, the battery may require replacement.
 2. Unplug all connected devices.
 3. Confirm the outlet you are connecting to works by plugging in another device.
-4. Plug in the AC Adapter to the wall and computer. Laptops have a charging indicator in front with a light. Please provide the light color(s) and icon underneath it to the support team. 
-   * 4A. If the battery is removable, unplug the machine, remove the battery, and plug the machine back into the power source without the battery installed. Please provide the light status to the support team. 
-5. To perform a hardware reset, unplug the system. Disconnect the CMOS battery for 30 seconds. Reconnect the CMOS battery and turn the computer on with the battery installed and the AC Adapter plugged in. Instructions to disconnect the CMOS battery can be found for your model [here](https://tech-docs.system76.com/models/README.html). 
+4. Plug in the AC Adapter to the wall and computer. Laptops have a charging indicator in front with a light. Please provide the light color(s) and icon underneath it to the support team.
+   * 4A. If the battery is removable, unplug the machine, remove the battery, and plug the machine back into the power source without the battery installed. Please provide the light status to the support team.
+5. To perform a hardware reset, unplug the system. Disconnect the CMOS battery for 30 seconds. Reconnect the CMOS battery and turn the computer on with the battery installed and the AC Adapter plugged in. Instructions to disconnect the CMOS battery can be found for your model [here](https://tech-docs.system76.com/models/README.html).
 6. If the keyboard backlight (both multi color and single color) comes on but nothing is on the display try the following steps:
   * 6a. Connect an external display if possible
-  * 6b. Remove the bottom cover of the system (if you are comfortable) and remove one stick of RAM if you have more then one. This will allow us to test both sticks as a bad stick of RAM can cause a system to not boot. Refer to this [article](https://support.system76.com/articles/service-manuals/) to find the service manual for your system.
+  * 6b. Remove the bottom cover of the system (if you are comfortable) and remove one stick of RAM if you have more then one. This will allow us to test both sticks as a bad stick of RAM can cause a system to not boot. Refer to this [article](/articles/service-manuals) to find the service manual for your system.
 7. If the laptop fails to power on after initial troubleshooting, sending in your laptop for repair is the next recommended step which can be done by opening a support ticket on our website.
-

--- a/content/switch-from-macos-to-popos.md
+++ b/content/switch-from-macos-to-popos.md
@@ -96,8 +96,8 @@ macOS' default is to place the Dock at the bottom of the screen.
 The Dock can be moved in both OSes. macOS has this feature in System Preferences; Pop!\_OS accomplishes this change with a GNOME extension.
 
 For more information on GNOME extensions, refer to the following support articles:
-[Customize Pop!\_OS](https://support.system76.com/articles/customize-gnome/)
-[Dock Customization](https://support.system76.com/articles/dash-to-dock/)
+[Customize Pop!\_OS](/articles/customize-gnome)
+[Dock Customization](/articles/dash-to-dock)
 
 [Return to Table of Contents](#Contents)
 
@@ -192,9 +192,9 @@ Starting in version 20.04, Pop!\_OS now includes a tiling window-manager as a GN
 
 More info about Pop!\_Shell here:
 
-[Pop!\_OS 20.04 Release Notes](https://support.system76.com/articles/Pop!_OS-20.04-LTS-Release-Notes/)
+[Pop!\_OS 20.04 Release Notes](/articles/Pop!_OS-20.04-LTS-Release-Notes)
 
-[Pop-Shell Keyboard Shortcuts](https://support.system76.com/articles/pop-keyboard-shortcuts/)
+[Pop-Shell Keyboard Shortcuts](/articles/pop-keyboard-shortcuts)
 
 
 [Return to Table of Contents](#Contents)
@@ -429,7 +429,7 @@ Additional codecs can be added with the following commands:
     sudo add-apt-repository multiverse
     sudo apt install ubuntu-restricted-extras
 
-We also have a help article for installing codecs [here](https://support.system76.com/articles/codecs/)
+We also have a help article for installing codecs [here](/articles/codecs)
 
 Another popular alternative is VLC Media Player. This software is available in the Pop!\_Shop, and offers many customizable features.
 
@@ -468,9 +468,9 @@ There is also a Linux client for the popular streaming service Spotify, availabl
 
 Pop!\_OS supports two (2) professional video editing suites. Lightworks and DaVinci Resolve. We have help articles on how to install both, which are listed below:
 
-[Lightworks](https://support.system76.com/articles/install-lightworks/)
+[Lightworks](/articles/install-lightworks)
 
-[DaVinci Resolve](https://support.system76.com/articles/install-davinci-resolve/)
+[DaVinci Resolve](/articles/install-davinci-resolve)
 
 There is also an open-source video editing program called Kden Live which offers a comparable interface and feature-set to iMovie, and is available in the Pop!\_Shop.
 
@@ -680,7 +680,7 @@ The snapshot feature is comparable to snapshots offered by virtual machine manag
 
 Déjà Dup Backups is closer in functionality to Time Machine. It offers local hardware backups, or backups to network locations. Folders and files can be added to the backup list manually, and it backs up the Home folder by default. Automatic backups can also be run on a schedule.
 
-To read more about methods of backing up your system visit our help article: [Backup Files](https://support.system76.com/articles/backup-files/)
+To read more about methods of backing up your system visit our help article: [Backup Files](/articles/backup-files)
 
 ### Give Pop!_OS a try!
 
@@ -690,4 +690,4 @@ If you want to try Pop!_OS yourself you can grab the OS image (ISO) from this [l
 
 <!-- # [What if I have an iPhone?](#iphone)
 
-For more details about how to manage files and backups between iPhone and Pop!\_OS, visit our help article: [Use an iPhone with Pop!\_OS](https://support.system76.com/articles/use-iphone-with-linux) -->
+For more details about how to manage files and backups between iPhone and Pop!\_OS, visit our help article: [Use an iPhone with Pop!\_OS](/articles/use-iphone-with-linux) -->

--- a/content/use-docking-station.md
+++ b/content/use-docking-station.md
@@ -100,7 +100,7 @@ Laptop -> Docking Station -> Monitor 1 -> DisplayPort Cable or Thunderbolt Cable
 We have tested the following docks:
  - [Plugable UD-CA1A](https://plugable.com/products/ud-ca1a/) [works with NVIDIA and Intel systems] <sup>1,2,3</sup>
    - All features work.
- 
+
 ### Community-tested docks:
 
 Community members have reported that the following docks work with our products:
@@ -115,7 +115,7 @@ Community members have reported that the following docks work with our products:
    - Requires extra configuration for suspend/resume to work.
  - [Lenovo ThinkPad Thunderbolt 3 Workstation Dock Gen 2](https://www.lenovo.com/us/en/accessories-and-monitors/docking/universal-cable-docks-thunderbolt/TBT-WS-Dock-Gen-2/p/40ANY230US) [[community-tested](https://github.com/system76/docs/pull/517) on an Intel sytem] <sup>1</sup>
  - [Lenovo ThinkPad USB 3.0 Pro Dock](https://support.lenovo.com/us/en/solutions/acc100184-thinkpad-usb-30-pro-dock-overview-and-service-parts) [[community-tested](https://github.com/system76/docs/pull/523) on an Intel system]
-   - Ethernet and DVI ports not tested. 
+   - Ethernet and DVI ports not tested.
  - [Plugable UD-ULTCDL Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
 
 ### For Intel systems
@@ -145,7 +145,7 @@ To uninstall the DisplayLink driver this command will be used:
 sudo displaylink-installer uninstall
 ```
 
-For installing the NVIDIA Driver that we provide you can use this support article: [System76 NVIDIA Driver](http://support.system76.com/articles/system76-driver/).
+For installing the NVIDIA Driver that we provide you can use this support article: [System76 NVIDIA Driver](/articles/system76-driver).
 
 <sup>1</sup> Does not need the DisplayLink Driver installed to work.  
 <sup>2</sup> On the Gazelle 15 (gaze15), requires GTX 1660 Ti graphics for video output via DisplayPort over USB-C.  


### PR DESCRIPTION
Please stop linking to things with `https://github.com/system76/docs/blob/gh-pages` and `https://github.com/system76/docs/raw/gh-pages`. All of those files are served with the website, you can just do `/pdfs` or `/files/firmware` instead.