### PR TITLE
fix absolute path markdown links for static files

### DIFF
--- a/modules/link-fixes.js
+++ b/modules/link-fixes.js
@@ -1,0 +1,28 @@
+import { extname } from 'path'
+
+function maybeFixLink (node) {
+  if (node.tag === 'nuxt-link') {
+    const ext = extname(node.props.to)
+
+    if (ext !== '') {
+      node.tag = 'a'
+      node.props.href = node.props.to
+      node.props.rel = ['nofollow', 'noopener', 'noreferrer']
+      node.props.target = '_blank'
+
+      delete node.props.to
+    }
+  }
+
+  if (node.children != null) {
+    node.children.forEach(maybeFixLink)
+  }
+}
+
+export default function (document) {
+  if (document.extension !== '.md') {
+    return
+  }
+
+  document.body.children.forEach(maybeFixLink)
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,5 @@
 import githubContributors from './modules/github-contributors'
+import linkFixes from './modules/link-fixes'
 
 export default {
   target: 'static',
@@ -75,6 +76,9 @@ export default {
   },
 
   hooks: {
-    'content:file:beforeInsert': githubContributors
+    'content:file:beforeInsert': doc => Promise.all([
+      githubContributors(doc),
+      linkFixes(doc)
+    ])
   }
 }


### PR DESCRIPTION
This should fix the absolute links not working for static file assets.