### PR TITLE
Fail builds if there is an error during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "nuxt dev",
-    "build": "nuxt generate",
+    "build": "nuxt generate --fail-on-error",
     "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",
     "lint": "npm run lint:js"
   },


### PR DESCRIPTION
Nuxt by default will just log errors. We seem to be missing them, so this will just fail CI or Deploy if there is an error logged.