### PR TITLE
Setup a markdown linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
   - pull_request
 
 jobs:
-  Lint:
+  Lint_JS:
+    name: Lint (Javascript)
     runs-on: ubuntu-latest
 
     steps:
@@ -22,7 +23,29 @@ jobs:
         run: npm ci
 
       - name: Lint
-        run: npm run lint
+        run: npm run lint:js
+
+  Lint_MD:
+    name: Lint (Markdown)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Setup Markdown
+        uses: xt0rted/markdownlint-problem-matcher@v1
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:md
 
   Build:
     runs-on: ubuntu-latest

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,16 @@
+{
+  "default": true,
+
+  "MD013": false,
+
+  "MD033": {
+    "allowed_elements": [
+      "font-awesome-icon",
+      "kbd",
+      "sup",
+      "u"
+    ]
+  },
+
+  "MD040": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5349,6 +5349,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -8594,6 +8603,12 @@
         "schema-utils": "^3.0.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -8888,6 +8903,12 @@
       "requires": {
         "fs-memo": "^1.2.0"
       }
+    },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true
     },
     "get-stream": {
       "version": "6.0.1",
@@ -10312,6 +10333,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -10501,6 +10528,15 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "listhen": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/listhen/-/listhen-0.2.4.tgz",
@@ -10612,6 +10648,18 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.differencewith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
+      "integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
@@ -10732,6 +10780,33 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-it": {
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
+      "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+          "dev": true
+        }
+      }
+    },
     "markdown-table": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -10739,6 +10814,51 @@
       "requires": {
         "repeat-string": "^1.0.0"
       }
+    },
+    "markdownlint": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
+      "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
+      "dev": true,
+      "requires": {
+        "markdown-it": "12.0.4"
+      }
+    },
+    "markdownlint-cli": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.27.1.tgz",
+      "integrity": "sha512-p1VV6aSbGrDlpUWzHizAnSNEQAweVR3qUI/AIUubxW7BGPXziSXkIED+uRtSohUlRS/jmqp3Wi4es5j6fIrdeQ==",
+      "dev": true,
+      "requires": {
+        "commander": "~7.1.0",
+        "deep-extend": "~0.6.0",
+        "get-stdin": "~8.0.0",
+        "glob": "~7.1.6",
+        "ignore": "~5.1.8",
+        "js-yaml": "^4.0.0",
+        "jsonc-parser": "~3.0.0",
+        "lodash.differencewith": "~4.5.0",
+        "lodash.flatten": "~4.4.0",
+        "markdownlint": "~0.23.1",
+        "markdownlint-rule-helpers": "~0.14.0",
+        "minimatch": "~3.0.4",
+        "minimist": "~1.2.5",
+        "rc": "~1.2.8"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
+          "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==",
+          "dev": true
+        }
+      }
+    },
+    "markdownlint-rule-helpers": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.14.0.tgz",
+      "integrity": "sha512-vRTPqSU4JK8vVXmjICHSBhwXUvbfh/VJo+j7hvxqe15tLJyomv3FLgFdFgb8kpj0Fe8SsJa/TZUAXv7/sN+N7A==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -11342,6 +11462,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.23",
@@ -16637,6 +16763,12 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
       "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
     "ufo": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.7.5.tgz",
@@ -17359,7 +17491,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "nuxt dev",
     "build": "nuxt generate --fail-on-error",
-    "lint": "eslint --ext \".js,.vue\" --ignore-path .gitignore ."
+    "lint:js": "eslint --ext \".js,.vue\" --ignore-path .gitignore .",
+    "lint:md": "markdownlint content/"
   },
   "dependencies": {
     "@fortawesome/fontawesome": "^1.1.8",
@@ -28,6 +29,7 @@
     "eslint-plugin-nuxt": "^2.0.0",
     "eslint-plugin-vue": "^7.11.0",
     "lodash": "^4.17.21",
+    "markdownlint-cli": "^0.27.1",
     "nuxt-dynamic-images": "0.0.1",
     "postcss": "^8.3.5",
     "shiki": "^0.9.3",


### PR DESCRIPTION
This PR sets up a markdown linter for all of the article files. This will display nicely for PRs which should make it easier for contributors.

I have disabled some rules like line length, code blocks requiring a language, and white listed some allowed html tags that we use.

Example output for the accessibility article:

```
content/accessibility.md:17 MD025/single-title/single-h1 Multiple top-level headings in the same document [Context: "# Accessibility"]
content/accessibility.md:19 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]
content/accessibility.md:19:94 MD026/no-trailing-punctuation Trailing punctuation in heading [Punctuation: '.']
content/accessibility.md:25 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## Screen Readers"]
content/accessibility.md:39 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## Universal Access Options"]
content/accessibility.md:43 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "1. **Seeing**. This section co..."]
content/accessibility.md:48:1 MD005/list-indent Inconsistent indentation for list items at the same level [Expected: 4; Actual: 1]
content/accessibility.md:48:1 MD010/no-hard-tabs Hard tabs [Column: 1]
content/accessibility.md:49:1 MD005/list-indent Inconsistent indentation for list items at the same level [Expected: 4; Actual: 1]
content/accessibility.md:49:1 MD010/no-hard-tabs Hard tabs [Column: 1]
content/accessibility.md:51:1 MD010/no-hard-tabs Hard tabs [Column: 1]
content/accessibility.md:52:1 MD010/no-hard-tabs Hard tabs [Column: 1]
content/accessibility.md:53:1 MD029/ol-prefix Ordered list item prefix [Expected: 3; Actual: 4; Style: 1/2/3]
content/accessibility.md:54:1 MD010/no-hard-tabs Hard tabs [Column: 1]
content/accessibility.md:55:1 MD010/no-hard-tabs Hard tabs [Column: 1]
content/accessibility.md:56:1 MD010/no-hard-tabs Hard tabs [Column: 1]
content/accessibility.md:57:1 MD010/no-hard-tabs Hard tabs [Column: 1]
content/accessibility.md:63 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## Keyboard Shortcuts & Modifiers"]
content/accessories.md:17 MD025/single-title/single-h1 Multiple top-level headings in the same document [Context: "# Order Accessories"]
content/accessories.md:19:64 MD033/no-inline-html Inline HTML [Element: i]
```

As you can see, this will standardize and fix some header issues. Header 1 is required to start every document. Then every header goes in the correct order. This will help with table of contents on articles which is awesome!

Along with headers, it makes indentation consistent for lists, ensures they are incremented correctly (no 1, 2, 3, 3 in lists.) 

You can see the full list of rules (some are disabled) here: https://github.com/DavidAnson/markdownlint#rules--aliases

I'd highly recommend this to clean up the doc pages and hopefully eliminate some of your work with PRs. We can merge it now, and I can open another PR to fix all the current docs.