### PR TITLE
Update DisplayLink driver information

### DIFF
--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -69,35 +69,35 @@ Community members have reported that the following docks work with our products:
   - Ethernet and DVI ports not tested.
 - [Plugable UD-ULTCDL Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
 
-## For Intel systems
+<sup>1</sup> Does not need the DisplayLink Driver installed to work.  
+<sup>2</sup> On the Gazelle 15 (gaze15), requires GTX 1660 Ti graphics for video output via DisplayPort over USB-C.  
+<sup>3</sup> NVIDIA cards have some minor graphic issues with what is rendered under the mouse as well as scrollbars.
 
-You'll need to install the 'dkms' package to install DisplayLink Driver. The NVIDIA Driver installs this package automatically.
+## Installing the DisplayLink Driver
+
+**Note:** The DisplayLink driver should only be installed if you are using a docking station that requires it. The DisplayLink driver may cause graphical issues with non-DisplayLink devices.
+
+On Intel or AMD graphics systems, you'll need to install the 'dkms' package to install DisplayLink driver. On NVIDIA graphics systems, the NVIDIA driver installs this package automatically.
 
 ```bash
 sudo apt install dkms
 ```
 
-## Installing DisplayLink Driver
+Download the newest [DisplayLink driver](http://www.displaylink.com/downloads/ubuntu) from the linked webpage.
 
-To download the newest [DisplayLink driver](http://www.displaylink.com/downloads/ubuntu) with the link in orange.
-
-To install the DisplayLink Driver, open the Terminal and move to the Downloads directory (the version for the driver may change, so look at the file name and change it accordingly):
+To install the DisplayLink driver, open the Terminal and move to the Downloads directory (the version for the driver may change, so look at the file name and change it accordingly):
 
 ```bash
 cd Downloads
-unzip DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu\ 5.2.zip
-sudo chmod +x displaylink-driver-5.2.14.run
-sudo ./displaylink-driver-5.2.14.run
+unzip DisplayLink\ USB\ Graphics\ Software\ for\ Ubuntu5.4-EXE.zip
+sudo chmod +x displaylink-driver-5.4.0-55.153.run
+sudo ./displaylink-driver-5.4.0-55.153.run
 ```
 
-To uninstall the DisplayLink driver this command will be used:
+To uninstall the DisplayLink driver, use this command:
 
 ```bash
 sudo displaylink-installer uninstall
 ```
 
-For installing the NVIDIA Driver that we provide you can use this support article: [System76 NVIDIA Driver](/articles/system76-driver).
-
-<sup>1</sup> Does not need the DisplayLink Driver installed to work.  
-<sup>2</sup> On the Gazelle 15 (gaze15), requires GTX 1660 Ti graphics for video output via DisplayPort over USB-C.  
-<sup>3</sup> NVIDIA cards have some minor graphic issues with what is rendered under the mouse as well as scrollbars.
+To install the NVIDIA driver that we provide, see the [System76 NVIDIA Driver](/articles/system76-driver) support article.


### PR DESCRIPTION
Closes #735, updates the version numbers/filenames in the example commands, and makes a couple of small wording improvements for clarity. Also moves the three disclaimers above the DisplayLink section since they apply more to the device lists higher up on the page.