### PR TITLE
add missing cd command during arch driver install

### DIFF
--- a/content/system76-driver.md
+++ b/content/system76-driver.md
@@ -78,6 +78,7 @@ Run these commands in a <u>Terminal</u> to clone, build and install the <u>Syste
 
 ```bash
 git clone https://aur.archlinux.org/system76-firmware.git
+cd system76-firmware
 makepkg -srcif
 sudo systemctl enable --now system76-firmware-daemon
 ```


### PR DESCRIPTION
To be consistent with other, similar instructions like, https://github.com/system76/docs/blame/master/content/system76-driver.md#L89