### PR TITLE
update firmware keys and add a link to the Open Firmware article

### DIFF
--- a/content/live-disk.md
+++ b/content/live-disk.md
@@ -127,7 +127,7 @@ After creating the live disk, insert the USB drive into your computer, then rebo
  Firmware             | Laptops                                                               | Desktops                                              |
  -------------------- | --------------------------------------------------------------------- | ----------------------------------------------------- |
  Proprietary Firmware | Hold <kbd>F7</kbd>/<kbd>F1</kbd>/<kbd>F2</kbd> | Hold <kbd>F12</kbd>, <kbd>F8</kbd>, or <kbd>F10</kbd>                        |
- Open Firmware        | Hold <kbd>Esc</kbd>                                                   |                                                       |
+ [Open Firmware](https://support.system76.com/articles/open-firmware-systems)        | Hold <kbd>Esc</kbd>      
 
 If done correctly, you should see a boot device selection menu, like one of the following images.
 

--- a/content/live-disk.md
+++ b/content/live-disk.md
@@ -127,7 +127,7 @@ After creating the live disk, insert the USB drive into your computer, then rebo
  Firmware             | Laptops                                                               | Desktops                                              |
  -------------------- | --------------------------------------------------------------------- | ----------------------------------------------------- |
  Proprietary Firmware | Hold <kbd>F7</kbd>/<kbd>F1</kbd>/<kbd>F2</kbd> | Hold <kbd>F12</kbd>, <kbd>F8</kbd>, or <kbd>F10</kbd>                        |
- [Open Firmware](https://support.system76.com/articles/open-firmware-systems)        | Hold <kbd>Esc</kbd>      
+ [Open Firmware](https://support.system76.com/articles/open-firmware-systems)        | Hold <kbd>Esc</kbd>                                            |
 
 If done correctly, you should see a boot device selection menu, like one of the following images.
 

--- a/content/pop-live-disk.md
+++ b/content/pop-live-disk.md
@@ -68,7 +68,7 @@ After creating the live disk, insert the USB into your computer, then reboot or 
  Firmware             | Laptops                                                               | Desktops                                              |
  -------------------- | --------------------------------------------------------------------- | ----------------------------------------------------- |
  Proprietary Firmware | Hold <kbd>F7</kbd>/<kbd>F1</kbd>/<kbd>F2</kbd> | Hold <kbd>F12</kbd>, <kbd>F8</kbd>, or <kbd>F10</kbd>                        |
- [Open Firmware](https://support.system76.com/articles/open-firmware-systems)        | Hold <kbd>Esc</kbd>      
+ [Open Firmware](https://support.system76.com/articles/open-firmware-systems)        | Hold <kbd>Esc</kbd>                                            |
 
 If done correctly, you should see a boot device selection menu, like one of the following images.
 

--- a/content/pop-live-disk.md
+++ b/content/pop-live-disk.md
@@ -16,6 +16,7 @@ twitterImage: /_social/article
 
 hidden: false
 section: hardware-troubleshooting
+tableOfContents: true
 ---
 
 Pop!_OS is remarkably flexible. You can run a full version of Pop!_OS from a USB drive (often known as a thumb drive, flash drive, or USB stick) in what's known as a *live environment*. Using a live environment (live disk) is useful for:
@@ -64,9 +65,10 @@ Once the flash is complete (should look like the screenshot above), it's time to
 
 After creating the live disk, insert the USB into your computer, then reboot or power on your system. You'll need to tell the computer to boot from the live disk by holding a key right as you power on:
 
-Laptops                             | Desktops
------------------------------------ | ------------------------------------
-Hold <kbd>F7</kbd> or <kbd>F1</kbd> | Hold <kbd>F12</kbd>, <kbd>F8</kbd>, or <kbd>F10</kbd>
+ Firmware             | Laptops                                                               | Desktops                                              |
+ -------------------- | --------------------------------------------------------------------- | ----------------------------------------------------- |
+ Proprietary Firmware | Hold <kbd>F7</kbd>/<kbd>F1</kbd>/<kbd>F2</kbd> | Hold <kbd>F12</kbd>, <kbd>F8</kbd>, or <kbd>F10</kbd>                        |
+ [Open Firmware](https://support.system76.com/articles/open-firmware-systems)        | Hold <kbd>Esc</kbd>      
 
 If done correctly, you should see a boot device selection menu, like one of the following images.
 


### PR DESCRIPTION
This PR does the following:
- Adds the updated table for booting keys from the live-disk article to the pop-live-disk article
- Updated the live-disk and pop-live-disk articles to have a link to the Open Firmware system article

This clears up some confusion with which keys to use to boot to the BIOS and Boot Menu for Open Firmware systems.