### PR TITLE
update pop shell for Manjaro

### DIFF
--- a/content/pop-shell.md
+++ b/content/pop-shell.md
@@ -70,7 +70,8 @@ make local-install
 
 #### For Manjaro
 
-<u>Pop Shell</u> is available in the repository: 
+<u>Pop Shell</u> is available in the repository:
+
 ```bash
 sudo pamac install gnome-shell-extension-pop-shell
 ```

--- a/content/pop-shell.md
+++ b/content/pop-shell.md
@@ -70,6 +70,9 @@ make local-install
 
 #### For Manjaro
 
-<u>Pop Shell</u> is already installed by default on the Manjaro GNOME edition but it needs to be enabled in the <u>Extenstions</u> application.
+<u>Pop Shell</u> is available in the repository: 
+```bash
+sudo pamac install gnome-shell-extension-pop-shell
+```
 
 To learn about <u>Pop Shell</u>'s keyboard shortcuts you can view this [support article](/articles/pop-keyboard-shortcuts/). You can also view <u>Pop Shell</u>'s source code [here](https://github.com/pop-os/shell).


### PR DESCRIPTION
Pop Shell no longer installed by default for Manjaro but according to this is available in the repository:

https://forum.manjaro.org/t/pop-shell-toggle-in-layouts-doesnt-work/68182/5