### PR TITLE
Report extension is not implicit

### DIFF
--- a/content/battery.md
+++ b/content/battery.md
@@ -89,7 +89,7 @@ powertop
 Powertop can also generate HTML reports with this command:
 
 ```bash
-sudo powertop --html=report
+sudo powertop --html=report.html
 ```
 
 Open the report located at `~/report.html` to see the results.


### PR DESCRIPTION
At least with PowerTOP version v2.11-1-g7ef7f79 the extension it isn't automatically added.