### PR TITLE
Updates to include plugable ud-ultc4k

### DIFF
--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -80,7 +80,7 @@ Community members have reported that the following docks work with our products:
 - [Lenovo ThinkPad USB 3.0 Pro Dock](https://support.lenovo.com/us/en/solutions/acc100184-thinkpad-usb-30-pro-dock-overview-and-service-parts) [[community-tested](https://github.com/system76/docs/pull/523) on an Intel system]
   - Ethernet and DVI ports not tested.
 - [Plugable UD-ULTCDL Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
-- [Plugable UD-ULTC4K USB-C Triple Display Dock](https://plugable.com/products/ud-ultc4k) [[community-tested](http://tbd.com/) on an NVIDIA system] <sup>4</sup>
+- [Plugable UD-ULTC4K USB-C Triple Display Dock](https://plugable.com/products/ud-ultc4k) [[community-tested](https://github.com/system76/docs/pull/790) on an NVIDIA system] <sup>4</sup>
 
 <sup>1</sup> Does not need the DisplayLink Driver installed to work.  
 <sup>2</sup> On the Gazelle 15 (gaze15), requires GTX 1660 Ti graphics for video output via DisplayPort over USB-C.  

--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -79,13 +79,12 @@ Community members have reported that the following docks work with our products:
 - [Lenovo ThinkPad Thunderbolt 3 Workstation Dock Gen 2](https://www.lenovo.com/us/en/accessories-and-monitors/docking/universal-cable-docks-thunderbolt/TBT-WS-Dock-Gen-2/p/40ANY230US) [[community-tested](https://github.com/system76/docs/pull/517) on an Intel sytem] <sup>1</sup>
 - [Lenovo ThinkPad USB 3.0 Pro Dock](https://support.lenovo.com/us/en/solutions/acc100184-thinkpad-usb-30-pro-dock-overview-and-service-parts) [[community-tested](https://github.com/system76/docs/pull/523) on an Intel system]
   - Ethernet and DVI ports not tested.
-- [Plugable UD-ULTCDL Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
-- [Plugable UD-ULTC4K USB-C Triple Display Dock](https://plugable.com/products/ud-ultc4k) [[community-tested](https://github.com/system76/docs/pull/790) on an NVIDIA system] <sup>4</sup>
+- [Plugable UD-ULTC4K USB-C Triple 4K Display Dock](https://plugable.com/products/ud-ultc4k) [[community-tested](https://github.com/system76/docs/pull/790) on an NVIDIA system] <sup>2,3</sup>
+- [Plugable UD-ULTCDL USB-C Triple Display Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
 
 <sup>1</sup> Does not need the DisplayLink Driver installed to work.  
-<sup>2</sup> On the Gazelle 15 (gaze15), requires GTX 1660 Ti graphics for video output via DisplayPort over USB-C.  
-<sup>3</sup> NVIDIA cards have some minor graphic issues with what is rendered under the mouse as well as scrollbars.  
-<sup>4</sup> On the Gazelle 16 (gaze16), requires the RTX 3060 graphics for video output via the USB 3.2 Gen 2 Type-C with DisplayPort 1.4 port at the rear of the device.
+<sup>2</sup> For video output via DisplayPort over USB-C, the Gazelle 15 (gaze15) requires GTX 1660 Ti graphics; the Gazelle 16 (gaze16) requires RTX 3060 graphics.  
+<sup>3</sup> NVIDIA cards have some minor graphical issues with what is rendered under the mouse as well as scrollbars.  
 
 ## Installing the DisplayLink Driver
 

--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -80,10 +80,12 @@ Community members have reported that the following docks work with our products:
 - [Lenovo ThinkPad USB 3.0 Pro Dock](https://support.lenovo.com/us/en/solutions/acc100184-thinkpad-usb-30-pro-dock-overview-and-service-parts) [[community-tested](https://github.com/system76/docs/pull/523) on an Intel system]
   - Ethernet and DVI ports not tested.
 - [Plugable UD-ULTCDL Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
+- [Plugable UD-ULTC4K USB-C Triple Display Dock](https://plugable.com/products/ud-ultc4k) [[community-tested](http://tbd.com/) on an NVIDIA system] <sup>4</sup>
 
 <sup>1</sup> Does not need the DisplayLink Driver installed to work.  
 <sup>2</sup> On the Gazelle 15 (gaze15), requires GTX 1660 Ti graphics for video output via DisplayPort over USB-C.  
-<sup>3</sup> NVIDIA cards have some minor graphic issues with what is rendered under the mouse as well as scrollbars.
+<sup>3</sup> NVIDIA cards have some minor graphic issues with what is rendered under the mouse as well as scrollbars.  
+<sup>4</sup> On the Gazelle 16 (gaze16), requires the RTX 3060 graphics for video output via the USB 3.2 Gen 2 Type-C with DisplayPort 1.4 port at the rear of the device.
 
 ## Installing the DisplayLink Driver
 


### PR DESCRIPTION
After [updating firmware to latest](https://github.com/system76/firmware-open/commit/14b8a6e967db28596d7108b7a925c60c416d7f45) on my gaze16_3060, I am now able to successfully use the Plugable ud-ultc4k for my needs, which include:

- Connecting two external displays via the DP++ ports on the dock - one display uses a DP -> HDMI adapter and the other uses a DP -> DVI adapter.
_Note: my displays are not pushing 4K resolutions - both max out at 1920 x 1080_
- Connect multiple USB devices (using all of the USB-A ports - haven't tested the USB-C port on front of dock):
  - USB headset
  - Logitech USB Unifying Receiver
  - Logitech USB Webcam
 - Connect Ethernet (confirmed link at 1Gbps)