### PR TITLE
update Ubuntu 20.04 LTS link

### DIFF
--- a/content/live-disk.md
+++ b/content/live-disk.md
@@ -36,7 +36,7 @@ A live disk is a handy tool to have around!
 
 ## Downloading the ISO
 
-In order to install Pop!_OS or Ubuntu, you must first download the .iso image. This is a disk image with the operating system and installer on it. You can [download Pop!_OS here](https://pop.system76.com) or [Ubuntu 20.04 here](https://ubuntu.com/download/desktop/thank-you?version=20.04.2.0&architecture=amd64).
+In order to install Pop!_OS or Ubuntu, you must first download the .iso image. This is a disk image with the operating system and installer on it. You can [download Pop!_OS here](https://pop.system76.com) or [Ubuntu 20.04 here](https://ubuntu.com/download/desktop).
 
 ## Verifying the Download
 


### PR DESCRIPTION
This PR does the following:
- Changes the link to a generic desktop download link

This is better for the following releases:
- 20.04 LTS as the current LTS will be on the top of the page so the customer will need to press the Download link
- The next time we will need to update this section will be when 22.04 LTS comes out and it will still be on the top of this page I believe. 