### PR TITLE
Update pop-keyboard-shortcuts.md

### DIFF
--- a/content/pop-keyboard-shortcuts.md
+++ b/content/pop-keyboard-shortcuts.md
@@ -81,7 +81,7 @@ The launcher allows searching through open windows and installed applications, a
 | <kbd><font-awesome-icon :icon="['fab', 'pop-os']"></font-awesome-icon></kbd>                 | Activate the launcher on Pop 21.04+ |
 | <kbd><font-awesome-icon :icon="['fab', 'pop-os']"></font-awesome-icon></kbd> + <kbd>/</kbd>  | Activate the launcher on Pop 20.10 and below |
 | `recent filename`                                          | Browse and search recent files  |
-| `/` / `~`                                                  | Browse the filesystem           |
+| `/` / `~/`                                                 | Browse the filesystem           |
 | `file filename`                                            | Search the filesystem for a certain file |
 | `t:`                                                       | Execute a command in a terminal |
 | `:`                                                        | Execute a command in sh         |


### PR DESCRIPTION
I think there should be a trailing slash on the tilde?  This enables me on Pop! 21.04 to browse my home folder, ~ just leaves me with an empty menu.