### PR TITLE
Update arch software

### DIFF
--- a/content/system76-driver.md
+++ b/content/system76-driver.md
@@ -70,8 +70,6 @@ In addition to the standard packages, that will pull in the latest NVIDIA driver
 
 **DISCLAIMER:** This section explains how to install the <u>System76 Driver</u> on Arch and Fedora.
 
-**NOTE** at this time it is recommended to use the NVIDIA driver from the Arch and Fedora repositories.
-
 Except in some rare cases, System76 QA and Engineering teams do not test other OSes on our hardware. This section is provided for informational purposes only. System76 encourages users to take ownership of their machines and install whatever software or operating systems they prefer.
 
 However, System76 does not guarantee the success or quality of experience when installing other Operating Systems.
@@ -79,7 +77,9 @@ Support typically makes best-efforts to offer direction or troubleshooting for o
 
 We may determine that troubleshooting has exceeded the scope of support. If that's the case, further questions should be referred to those Operating System(s)' support forums.
 
-#### Arch
+**NOTE** at this time it is recommended to use the NVIDIA driver from the Arch and Fedora repositories.
+
+### Arch
 
 First let's install some packages needed for the build process of the <u>System76 Firmware Daemon</u> and the <u>System76 Driver</u>:
 
@@ -106,14 +106,14 @@ makepkg -srcif
 sudo systemctl enable --now system76
 ```
 
-**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE** choose the first software option listed after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-driver
 sudo systemctl enable --now system76
 ```
 
-#### Fedora
+### Fedora
 
 Run these commands in a <u>Terminal</u> to enable the [community Fedora COPR](https://copr.fedorainfracloud.org/coprs/szydell/system76/) and install the <u>System76 Driver</u> :
 

--- a/content/system76-driver.md
+++ b/content/system76-driver.md
@@ -75,13 +75,12 @@ First let's install some packages needed for the build process of the <u>System7
 sudo pacman -S --needed base-devel git linux-headers
 ```
 
-Run these commands in a <u>Terminal</u> to clone, build and install the <u>System76 Firmware Daemon</u>:
+### Install Paru
 
 ```bash
-git clone https://aur.archlinux.org/system76-firmware.git
-cd system76-firmware
-makepkg -srcif
-sudo systemctl enable --now system76-firmware-daemon
+git clone https://aur.archlinux.org/paru.git
+cd paru
+makepkg -si
 ```
 
 Now the <u>System76 Driver</u> can be cloned, built and installed using these commands:
@@ -90,6 +89,11 @@ Now the <u>System76 Driver</u> can be cloned, built and installed using these co
 git clone https://aur.archlinux.org/system76-driver.git
 cd system76-driver
 makepkg -srcif
+sudo systemctl enable --now system76
+```
+
+```bash
+paru -s system76-driver
 sudo systemctl enable --now system76
 ```
 

--- a/content/system76-driver.md
+++ b/content/system76-driver.md
@@ -70,7 +70,7 @@ In addition to the standard packages, that will pull in the latest NVIDIA driver
 
 **DISCLAIMER:** This section explains how to install the <u>System76 Driver</u> on Arch and Fedora.
 
-**NOTE** at this time it is recommended to use the NVIDIA driver from the Arch and Fedora repositories. 
+**NOTE** at this time it is recommended to use the NVIDIA driver from the Arch and Fedora repositories.
 
 Except in some rare cases, System76 QA and Engineering teams do not test other OSes on our hardware. This section is provided for informational purposes only. System76 encourages users to take ownership of their machines and install whatever software or operating systems they prefer.
 

--- a/content/system76-driver.md
+++ b/content/system76-driver.md
@@ -56,9 +56,21 @@ sudo apt install system76-driver
 
 This installs the System76 driver and related utilities which are needed to enable full functionality for your system.
 
+## Installing the System76 NVIDIA Driver for Systems with NVIDIA GPUs
+
+If your system has an NVIDIA graphics card, you will want to go ahead and use this command to install the System76 Driver with NVIDIA graphics drivers built-in:
+
+```bash
+sudo apt-get install system76-driver-nvidia
+```
+
+In addition to the standard packages, that will pull in the latest NVIDIA drivers as packaged by System76, and all related packages needed to take full advantage of your dedicated NVIDIA graphics card.
+
 ### Install System76 Driver on Other Operating Systems
 
 **DISCLAIMER:** This section explains how to install the <u>System76 Driver</u> on Arch and Fedora.
+
+**NOTE** at this time it is recommended to use the NVIDIA driver from the Arch and Fedora repositories. 
 
 Except in some rare cases, System76 QA and Engineering teams do not test other OSes on our hardware. This section is provided for informational purposes only. System76 encourages users to take ownership of their machines and install whatever software or operating systems they prefer.
 
@@ -83,7 +95,7 @@ cd paru
 makepkg -si
 ```
 
->**NOTE** that by default <u>Paru</u> uses vim standards so when you see a ":" press the <kbd>q</kbd> key to continue. You may also need to import some public keys by using the <kbd>y</kbd> key.
+**NOTE** that by default <u>Paru</u> uses vim standards so when you see a ":" press the <kbd>q</kbd> key to continue. You may also need to import some public keys by using the <kbd>y</kbd> key.
 
 Now the <u>System76 Driver</u> can be cloned, built and installed using these commands:
 
@@ -94,7 +106,7 @@ makepkg -srcif
 sudo systemctl enable --now system76
 ```
 
->**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-driver
@@ -109,13 +121,3 @@ Run these commands in a <u>Terminal</u> to enable the [community Fedora COPR](ht
 sudo dnf copr enable szydell/system76
 sudo dnf install system76-driver
 ```
-
-## Installing the System76 NVIDIA Driver for Systems with NVIDIA GPUs
-
-If your system has an NVIDIA graphics card, you will want to go ahead and use this command to install the System76 Driver with NVIDIA graphics drivers built-in:
-
-```bash
-sudo apt-get install system76-driver-nvidia
-```
-
-In addition to the standard packages, that will pull in the latest NVIDIA drivers as packaged by System76, and all related packages needed to take full advantage of your dedicated NVIDIA graphics card.

--- a/content/system76-driver.md
+++ b/content/system76-driver.md
@@ -83,6 +83,8 @@ cd paru
 makepkg -si
 ```
 
+>**NOTE** that by default <u>Paru</u> uses vim standards so when you see a ":" press the <kbd>q</kbd> key to continue. You may also need to import some public keys by using the <kbd>y</kbd> key.
+
 Now the <u>System76 Driver</u> can be cloned, built and installed using these commands:
 
 ```bash
@@ -91,6 +93,8 @@ cd system76-driver
 makepkg -srcif
 sudo systemctl enable --now system76
 ```
+
+>**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-driver

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -29,9 +29,9 @@ We may determine that troubleshooting has exceeded the scope of support. If that
 
 Be sure to install the <u>System76 Driver</u> first. The steps to do that are [here](/articles/system76-driver).
 
-If you want to use a AUR helper like [Paru](https://github.com/Morganamilo/paru) then follow the steps below. 
+If you want to use a AUR helper like [Paru](https://github.com/Morganamilo/paru) then follow the steps on this [page](/articles/system76-driver) as well. 
 
-This command will install all of the packages
+This command will install all of the packages using Paru.
 
 ```bash
 paru -S system76-firmware-daemon system76-firmware firmware-manager system76-power gnome-shell-extension-system76-power-git system76-driver system76-dkms system76-acpi-dkms

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -51,7 +51,7 @@ sudo gpasswd -a $USER adm
 
 These commands will install it using <u>Paru</u>.
 
->**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-firmware-daemon
@@ -71,7 +71,7 @@ makepkg -srcif
 
 This command will install it using <u>Paru</u>.
 
->**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s firmware-manager
@@ -89,7 +89,7 @@ makepkg -srcif
 
 This command will install it using <u>Paru</u>.
 
->**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-dkms
@@ -107,7 +107,7 @@ makepkg -srcif
 
 This command will install it using <u>Paru</u>.
 
->**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-acpi-dkms
@@ -125,7 +125,7 @@ sudo gpasswd -a $USER adm
 
 These commands will install it using <u>Paru</u>.
 
->**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-power
@@ -143,7 +143,7 @@ makepkg -srcif
 
 This command will install it using <u>Paru</u>.
 
->**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s gnome-shell-extension-system76-power
@@ -159,7 +159,7 @@ makepkg -srcif
 
 This command will install it using <u>Paru</u>.
 
->**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-io-dkms
@@ -177,7 +177,7 @@ makepkg -srcif
 
 This command will install it using <u>Paru</u>.
 
->**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 <u>Paru</u> -s system76-acpi-oled
@@ -240,7 +240,7 @@ sudo dnf install system76-acpi-dkms
 sudo systemctl enable dkms
 ```
 
-> **NOTE:** After enabling the dkms systemd service for either the <u>System76 DKMS</u> or the <u>System76 ACPI DKMS</u> package you will need to reboot the system:
+**NOTE:** After enabling the dkms systemd service for either the <u>System76 DKMS</u> or the <u>System76 ACPI DKMS</u> package you will need to reboot the system:
 
 ```bash
 sudo systemctl reboot

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -29,7 +29,7 @@ We may determine that troubleshooting has exceeded the scope of support. If that
 
 Be sure to install the <u>System76 Driver</u> first. The steps to do that are [here](/articles/system76-driver).
 
-If you want to use a AUR helper like [Paru](https://github.com/Morganamilo/paru) then follow the steps on this [page](/articles/system76-driver) as well. 
+If you want to use a AUR helper like [Paru](https://github.com/Morganamilo/paru) then follow the steps on this [page](/articles/system76-driver) as well.
 
 This command will install all of the packages using Paru.
 
@@ -39,7 +39,7 @@ paru -S system76-firmware-daemon system76-firmware firmware-manager system76-pow
 
 ### System76 Firmware Daemon in Arch
 
-These commands will clone, build and install the <u>System76 Firmware Daemon</u> service. 
+These commands will clone, build and install the <u>System76 Firmware Daemon</u> service.
 
 ```bash
 git clone https://aur.archlinux.org/system76-firmware.git
@@ -59,7 +59,7 @@ sudo gpasswd -a $USER adm
 
 ### System76 Firmware Manager in Arch
 
-These commands will clone, build and install the <u>System76 Firmware Manager</u> application. 
+These commands will clone, build and install the <u>System76 Firmware Manager</u> application.
 
 ```bash
 git clone https://aur.archlinux.org/firmware-manager.git
@@ -75,7 +75,7 @@ paru -s firmware-manager
 
 ### System76 DKMS in Arch
 
-This package is needed for hotkeys and fan(s) on Closed Firmware systems. 
+This package is needed for hotkeys and fan(s) on Closed Firmware systems.
 
 ```bash
 git clone https://aur.archlinux.org/system76-dkms.git
@@ -175,7 +175,7 @@ Be sure to install the <u>System76 Driver</u> first and the steps to do that are
 
 ### System76 Firmware Manager in Fedora
 
-Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u>, enable the service and add your user to the adm group. 
+Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u>, enable the service and add your user to the adm group.
 
 ```bash
 sudo dnf install firmware-manager

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -29,7 +29,7 @@ We may determine that troubleshooting has exceeded the scope of support. If that
 
 Be sure to install the <u>System76 Driver</u> first. The steps to do that are [here](/articles/system76-driver).
 
-If you want to use a AUR helper like [Paru](https://github.com/Morganamilo/paru) then follow the steps on this [page](/articles/system76-driver) as well.
+If you want to use an AUR helper like [Paru](https://github.com/Morganamilo/paru) then follow the steps on this [page](/articles/system76-driver) as well.
 
 This command will install all of the packages using <u>Paru</u>.
 
@@ -49,9 +49,9 @@ sudo systemctl enable --now system76-firmware-daemon
 sudo gpasswd -a $USER adm
 ```
 
-These commands will install it using <u>Paru</u>.
+These commands will install `system76-firmware-daemon` using <u>Paru</u>.
 
-**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE:** choose the first software option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-firmware-daemon
@@ -69,9 +69,9 @@ cd firmware-manager
 makepkg -srcif
 ```
 
-This command will install it using <u>Paru</u>.
+This command will install `firmware-manager` using <u>Paru</u>.
 
-**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE:** choose the first software option after running the <u>Paru</u> command.
 
 ```bash
 paru -s firmware-manager
@@ -87,9 +87,9 @@ cd system76-dkms
 makepkg -srcif
 ```
 
-This command will install it using <u>Paru</u>.
+This command will install `system76-dkms` using <u>Paru</u>.
 
-**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE:** choose the first software option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-dkms
@@ -105,9 +105,9 @@ cd system76-acpi-dkms
 makepkg -srcif
 ```
 
-This command will install it using <u>Paru</u>.
+This command will install `system76-acpi-dkms` using <u>Paru</u>.
 
-**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE:** choose the first software option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-acpi-dkms
@@ -123,9 +123,9 @@ sudo systemctl enable --now system76-power
 sudo gpasswd -a $USER adm
 ```
 
-These commands will install it using <u>Paru</u>.
+These commands will install `system76-power` using <u>Paru</u>.
 
-**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE:** choose the first software option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-power
@@ -141,9 +141,9 @@ cd gnome-shell-extension-system76-power
 makepkg -srcif
 ```
 
-This command will install it using <u>Paru</u>.
+This command will install `gnome-shell-extension-system76-power` using <u>Paru</u>.
 
-**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE:** choose the first software option after running the <u>Paru</u> command.
 
 ```bash
 paru -s gnome-shell-extension-system76-power
@@ -157,9 +157,9 @@ cd system76-io-dkms
 makepkg -srcif
 ```
 
-This command will install it using <u>Paru</u>.
+This command will install `system76-io-dkms` using <u>Paru</u>.
 
-**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE:** choose the first software option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-io-dkms
@@ -177,7 +177,7 @@ makepkg -srcif
 
 This command will install it using <u>Paru</u>.
 
-**NOTE** use the first option after running the <u>Paru</u> command.
+**NOTE:** choose the first software option after running the <u>Paru</u> command.
 
 ```bash
 <u>Paru</u> -s system76-acpi-oled

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -29,9 +29,26 @@ We may determine that troubleshooting has exceeded the scope of support. If that
 
 Be sure to install the <u>System76 Driver</u> first. The steps to do that are [here](/articles/system76-driver).
 
+If you want to use a AUR helper like [Paru](https://github.com/Morganamilo/paru) then follow the steps below. 
+
+### Install Paru
+
+```bash
+sudo pacman -S --needed base-devel
+git clone https://aur.archlinux.org/paru.git
+cd paru
+makepkg -si
+```
+
+This command will install all of the packages
+
+```bash
+paru -S system76-firmware-daemon system76-firmware firmware-manager system76-power gnome-shell-extension-system76-power-git system76-driver system76-dkms system76-acpi-dkms
+```
+
 ### System76 Firmware Daemon in Arch
 
-These commands will clone, build and install the <u>System76 Firmware Daemon</u> service.
+These commands will clone, build and install the <u>System76 Firmware Daemon</u> service. 
 
 ```bash
 git clone https://aur.archlinux.org/system76-firmware.git
@@ -41,9 +58,17 @@ sudo systemctl enable --now system76-firmware-daemon
 sudo gpasswd -a $USER adm
 ```
 
+These commands will install it using Paru.
+
+```bash
+paru -s system76-firmware-daemon
+sudo systemctl enable --now system76-firmware-daemon
+sudo gpasswd -a $USER adm
+```
+
 ### System76 Firmware Manager in Arch
 
-These commands will clone, build and install the <u>System76 Firmware Manager</u> application.
+These commands will clone, build and install the <u>System76 Firmware Manager</u> application. 
 
 ```bash
 git clone https://aur.archlinux.org/firmware-manager.git
@@ -51,9 +76,15 @@ cd firmware-manager
 makepkg -srcif
 ```
 
+This command will install it using Paru.
+
+```bash
+paru -s firmware-manager
+```
+
 ### System76 DKMS in Arch
 
-This package is needed for hotkeys and fan(s) on Closed Firmware systems:
+This package is needed for hotkeys and fan(s) on Closed Firmware systems. 
 
 ```bash
 git clone https://aur.archlinux.org/system76-dkms.git
@@ -61,14 +92,26 @@ cd system76-dkms
 makepkg -srcif
 ```
 
+This command will install it using Paru.
+
+```bash
+paru -s system76-dkms
+```
+
 ### System76 ACPI DKMS in Arch
 
-This package is needed for hotkeys and fan(s) on Open Firmware systems:
+This package is needed for hotkeys and fan(s) on Open Firmware systems.
 
 ```bash
 git clone https://aur.archlinux.org/system76-acpi-dkms.git
 cd system76-acpi-dkms
 makepkg -srcif
+```
+
+This command will install it using Paru.
+
+```bash
+paru -s system76-acpi-dkms
 ```
 
 ### System76 Power in Arch
@@ -81,6 +124,14 @@ sudo systemctl enable --now system76-power
 sudo gpasswd -a $USER adm
 ```
 
+These commands will install it using Paru.
+
+```bash
+paru -s system76-power
+sudo systemctl enable --now system76-power
+sudo gpasswd -a $USER adm
+```
+
 ### System76 Power GNOME Shell Extension in Arch
 
 ```bash
@@ -89,7 +140,11 @@ cd gnome-shell-extension-system76-power
 makepkg -srcif
 ```
 
-**NOTE:** As of this writing the GNOME Shell Extension doesn't support GNOME 40.
+This command will install it using Paru.
+
+```bash
+paru -s gnome-shell-extension-system76-power
+```
 
 ### System76 Thelio Io DKMS in Arch
 
@@ -97,6 +152,12 @@ makepkg -srcif
 git clone https://aur.archlinux.org/system76-io-dkms.git
 cd system76-io-dkms
 makepkg -srcif
+```
+
+This command will install it using Paru.
+
+```bash
+paru -s system76-io-dkms
 ```
 
 **NOTE:** This package is only needed for Thelio desktops.
@@ -109,6 +170,12 @@ cd system76-acpi-oled
 makepkg -srcif
 ```
 
+This command will install it using Paru.
+
+```bash
+paru -s system76-acpi-oled
+```
+
 **NOTE:** This package is only needed for systems with OLED displays to control the brightness.
 
 ## Fedora
@@ -117,7 +184,7 @@ Be sure to install the <u>System76 Driver</u> first and the steps to do that are
 
 ### System76 Firmware Manager in Fedora
 
-Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u>,enable the service and add your user to the adm group:
+Then install the <u>System76 Firmware Manager</u> and the <u>System76 Firmware Daemon</u>, enable the service and add your user to the adm group. 
 
 ```bash
 sudo dnf install firmware-manager

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -31,15 +31,6 @@ Be sure to install the <u>System76 Driver</u> first. The steps to do that are [h
 
 If you want to use a AUR helper like [Paru](https://github.com/Morganamilo/paru) then follow the steps below. 
 
-### Install Paru
-
-```bash
-sudo pacman -S --needed base-devel
-git clone https://aur.archlinux.org/paru.git
-cd paru
-makepkg -si
-```
-
 This command will install all of the packages
 
 ```bash

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -31,7 +31,7 @@ Be sure to install the <u>System76 Driver</u> first. The steps to do that are [h
 
 If you want to use a AUR helper like [Paru](https://github.com/Morganamilo/paru) then follow the steps on this [page](/articles/system76-driver) as well.
 
-This command will install all of the packages using Paru.
+This command will install all of the packages using <u>Paru</u>.
 
 ```bash
 paru -S system76-firmware-daemon system76-firmware firmware-manager system76-power gnome-shell-extension-system76-power-git system76-driver system76-dkms system76-acpi-dkms
@@ -49,7 +49,9 @@ sudo systemctl enable --now system76-firmware-daemon
 sudo gpasswd -a $USER adm
 ```
 
-These commands will install it using Paru.
+These commands will install it using <u>Paru</u>.
+
+>**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-firmware-daemon
@@ -67,7 +69,9 @@ cd firmware-manager
 makepkg -srcif
 ```
 
-This command will install it using Paru.
+This command will install it using <u>Paru</u>.
+
+>**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s firmware-manager
@@ -83,7 +87,9 @@ cd system76-dkms
 makepkg -srcif
 ```
 
-This command will install it using Paru.
+This command will install it using <u>Paru</u>.
+
+>**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-dkms
@@ -99,7 +105,9 @@ cd system76-acpi-dkms
 makepkg -srcif
 ```
 
-This command will install it using Paru.
+This command will install it using <u>Paru</u>.
+
+>**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-acpi-dkms
@@ -115,7 +123,9 @@ sudo systemctl enable --now system76-power
 sudo gpasswd -a $USER adm
 ```
 
-These commands will install it using Paru.
+These commands will install it using <u>Paru</u>.
+
+>**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-power
@@ -131,7 +141,9 @@ cd gnome-shell-extension-system76-power
 makepkg -srcif
 ```
 
-This command will install it using Paru.
+This command will install it using <u>Paru</u>.
+
+>**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s gnome-shell-extension-system76-power
@@ -145,7 +157,9 @@ cd system76-io-dkms
 makepkg -srcif
 ```
 
-This command will install it using Paru.
+This command will install it using <u>Paru</u>.
+
+>**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
 paru -s system76-io-dkms
@@ -161,10 +175,12 @@ cd system76-acpi-oled
 makepkg -srcif
 ```
 
-This command will install it using Paru.
+This command will install it using <u>Paru</u>.
+
+>**NOTE** use the first option after running the <u>Paru</u> command.
 
 ```bash
-paru -s system76-acpi-oled
+<u>Paru</u> -s system76-acpi-oled
 ```
 
 **NOTE:** This package is only needed for systems with OLED displays to control the brightness.


### PR DESCRIPTION
This PR does the following:
- Updates software steps
- Removes the note about System76 Power GNOME Shell extension not working on GNOME 40 as it does now
- Adds Paru steps