### PR TITLE
Linux Gaming: Prioritize pop shop for installing steam

### DIFF
--- a/content/linux-gaming.md
+++ b/content/linux-gaming.md
@@ -20,6 +20,14 @@ tableOfContents: true
 
 ## Steam (Install)
 
+### Install Steam From the Pop!_Shop
+
+Open the <u>Pop!_Shop</u> application then either search for Steam or by clicking the <u>Steam</u> icon on the Pop!_Shop home page. Now click the **Install** button.
+
+![Pop!_Shop Steam](/images/linux-gaming/pop-shop_steam.png)
+
+Once installed, use the Activities Overview to search for and run <u>Steam</u>.
+
 ### Install Steam From Command Line
 
 Open the <u>Terminal</u> application by searching for <u>Terminal</u> after pressing the Super Key <kbd><font-awesome-icon :icon="['fab', 'ubuntu']"></font-awesome-icon></kbd>/<kbd><font-awesome-icon :icon="['fab', 'pop-os']"></font-awesome-icon></kbd>/<kbd>SUPER</kbd>.
@@ -41,14 +49,6 @@ sudo apt install steam
 ```
 
 **IMPORTANT NOTE:** Be very careful when using sudo with ANY Command. It can make system wide changes so be sure to read everything before entering 'Y'.
-
-### Install Steam From the Pop!_Shop
-
-Open the <u>Pop!_Shop</u> application then either search for Steam or by clicking the <u>Steam</u> icon on the Pop!_Shop home page. Now click the **Install** button.
-
-![Pop!_Shop Steam](/images/linux-gaming/pop-shop_steam.png)
-
-Once installed, use the Activities Overview to search for and run <u>Steam</u>.
 
 ### Enable Steam Play (Proton)
 


### PR DESCRIPTION
Since these articles are aimed at users who may be less comfortable with Linux, I think it makes sense to display Pop Shop as the first item, rather than terminal. I think for new users, the terminal is likely more of a fallback option, rather than their primary means of installing software.

This PR was motivated by this comment on Reddit from @mmstick: https://www.reddit.com/r/pop_os/comments/qqa44e/linus_tech_tips_switches_his_personal_pc_to_pop_os/hjz960n/