### PR TITLE
minor typo tweaks recovery, new chroot article

### DIFF
--- a/content/hardware-failure.md
+++ b/content/hardware-failure.md
@@ -86,13 +86,14 @@ From here use the <kbd>Down</kbd> to switch from Monitor to Stress by pressing t
 
 We can confirm whether there is an issue with the GPU in your system by using a benchmarking tool called [Unigine Heaven](https://benchmark.unigine.com/heaven).
 
-Click the 'Free Download' button and choose the Linux option in the dropdown. Once the download is complete, there should be a `Unigine_Heaven-4.0.run` file in the Downloads directory. 
+Click the 'Free Download' button and choose the Linux option in the dropdown. Once the download is complete, there should be a `Unigine_Heaven-4.0.run` file in the Downloads directory.
 
 From a terminal, navigate to the folder with the Unigine Heaven download:
 
 ```bash
 cd Downloads
 ```
+
 Run the following command:
 
 ```bash
@@ -116,6 +117,7 @@ Then the application can be started:
 ```bash
 ./heaven
 ```
+
 Click the 'Run' button to begin the program.
 
 ### GPU Burn (for NVIDIA GPU's only)

--- a/content/pop-recovery.md
+++ b/content/pop-recovery.md
@@ -64,9 +64,9 @@ If the existing OS install needs to be repaired, the installer application shoul
 
 **NOTE:** be sure not to choose any install or repair options, as this could result in data loss.
 
-To access the existing OS drive run the following terminal:
+To access the existing OS drive follow the instructions below.
 
-First, press `SUPER`+`T` to open a terminal, then type this command:
+First, press <kbd>SUPER</kbd>+<kbd>T</kbd> to open a terminal, then type this command:
 
 ```bash
 lsblk
@@ -119,7 +119,7 @@ sudo cp -n /etc/resolv.conf /mnt/etc/
 sudo chroot /mnt
 ```
 
-With this last command, you will have root access to your installed system. Once the drive is accessed, commands for maintenance can be run on the installed system. For example, [package manager repair commands](article/package-manager-pop). You can also access your files with <u>files</u> via "Other Locations" -> "Computer" -> "mnt."
+With this last command, you will have root access to your installed system. Once the drive is accessed, commands for maintenance can be run on the installed system. For example, [package manager repair commands](article/package-manager-pop). You can also access your files with <u>Files</u> via "Other Locations" -> "Computer" -> "mnt."
 
 ### After Chroot
 


### PR DESCRIPTION
This PR does the following:

- Creates a standalone article for chroot access.
     - This allows instructions for chrooting to be sent to users by themselves, instead of linking to other articles for larger concepts with the chroot nested inside.
- Fixes some minor formatting/typos in the Recovery article.
- Addresses issue: https://github.com/system76/docs/issues/821 