### PR TITLE
Update cuda cudnn

### DIFF
--- a/content/cuda.md
+++ b/content/cuda.md
@@ -32,6 +32,12 @@ sudo apt install system76-cudnn-11.2
 
 ### For older releases of The NVIDIA CUDA Toolkit
 
+To install CUDA 11.1
+
+```bash
+sudo apt install system76-cuda-11.1
+```
+
 To install CUDA 10.0:
 
 ```bash
@@ -94,10 +100,10 @@ To verify installation, run this command to see the current version of the NVIDI
 nvcc -V
 ```
 
-You can also check the version of the installer and patches installed with this command:
+You can check the version of cuDNN with this command:
 
 ```bash
-cat /usr/lib/cuda/version.txt
+cat /usr/lib/cuda/include/cudnn_version.h | grep CUDNN_MAJOR -A 2       
 ```
 
 ## Not running Pop!_OS?

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -44,7 +44,7 @@ For the respective cuDNN library:
 sudo apt install system76-cudnn-11.1
 ```
 
-#### These versions are only in Pop 20.04 LTS:
+#### These versions are only in Pop 20.04 LTS
 
 To install CUDA 10.0:
 

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -32,6 +32,8 @@ sudo apt install system76-cudnn-11.2
 
 ### For older releases of The NVIDIA CUDA Toolkit
 
+#### These versions are only in Pop 21.04
+
 To install CUDA 11.1
 
 ```bash

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -38,6 +38,14 @@ To install CUDA 11.1
 sudo apt install system76-cuda-11.1
 ```
 
+For the respective cuDNN library:
+
+```bash
+sudo apt install system76-cudnn-11.1
+```
+
+#### These versions are only in Pop 20.04 LTS:
+
 To install CUDA 10.0:
 
 ```bash
@@ -50,40 +58,28 @@ For the respective cuDNN library:
 sudo apt install system76-cudnn-10.0
 ```
 
-To install CUDA 9.2:
+To install CUDA 10.1:
 
 ```bash
-sudo apt install system76-cuda-9.2
+sudo apt install system76-cuda-10.1
 ```
 
 For the respective cuDNN library:
 
 ```bash
-sudo apt install system76-cudnn-9.2
+sudo apt install system76-cudnn-10.1
 ```
 
-To install CUDA 9.1:
+To install CUDA 10.2:
 
 ```bash
-sudo apt install system76-cuda-9.1
-```
-
-For the respective cuDNN library:
-
-```bash
-sudo apt install system76-cudnn-9.1
-```
-
-To install CUDA 9.0:
-
-```bash
-sudo apt install system76-cuda-9.0
+sudo apt install system76-cuda-10.2
 ```
 
 For the respective cuDNN library:
 
 ```bash
-sudo apt install system76-cudnn-9.0
+sudo apt install system76-cudnn-10.2
 ```
 
 ### Switch between different versions


### PR DESCRIPTION
This PR does the following:
- Removes a `cat` command that pointed to a file that doesn't exit
- Adds a new `cat` command to replace it to check cuDNN version instead
- Adds and removes CUDA/cuDNN versions as they are no longer packaged
- Adds information that certain CUDA/cuDNN versions are only on 20.04 LTS
- Addresses issue https://github.com/system76/docs/issues/765