### PR TITLE
Changed text for machine checks

### DIFF
--- a/content/hardware-failure.md
+++ b/content/hardware-failure.md
@@ -178,7 +178,7 @@ Then, after the system has crashed or been used for a period of time, take a loo
 journalctl -f -u rasdaemon
 ```
 
-If there is no log or the log is empty, then the crash isn't related to a hardware failure.  The log will stay empty until a MCE happens.  Take a look for "uncorrected" errors, as most "corrected" errors can be ignored.  If there are a consistent number of "uncorrected" errors, the hardware should be examined.
+If there is no log or the log is empty, then the crash isn't related to a hardware failure.  The log will stay empty until a MCE happens.  If you have ECC RAM, take a look for "uncorrected" errors, as most "corrected" errors can be ignored.  If there are a consistent number of "corrected" errors, the hardware should be examined.
 
 ## Won't Power On
 


### PR DESCRIPTION
I think that there is a typo in the memory section regarding corrected and uncorrected errors.  Customers without ECC RAM should never see corrected errors in their logs.  I also think you are intending to say that if you have ECC RAM and there are a large number of corrections in a short period of time it may still indicate a fault.