### PR TITLE
fix: typo in desktop-environment.md

### DIFF
--- a/content/desktop-environment.md
+++ b/content/desktop-environment.md
@@ -23,7 +23,7 @@ Pop!\_OS and Ubuntu both include the GNOME desktop environment by default. A des
 
 You can install an alternative desktop environment using the instructions below.
 
-**NOTE:** be careful when installing other desktop envioronments, as they may affect the default GNOME desktop (both Ubuntu and Pop).
+**NOTE:** be careful when installing other desktop environments, as they may affect the default GNOME desktop (both Ubuntu and Pop).
 
 If you run into trouble while using an alternative desktop environment, you may wish to revert to the default environment. To ensure the default GNOME desktop environment is installed in Pop!\_OS, install the `pop-desktop` package:
 


### PR DESCRIPTION
Just a small typo.

`envioronments` -> `environments`