### PR TITLE
User tested CableMatters docking station

### DIFF
--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -59,9 +59,7 @@ Community members have reported that the following docks work with our products:
 
 - [Anker A8392](https://us.anker.com/products/a8392) [[community-tested](https://github.com/system76/docs/pull/797) on an Intel system] <sup>1</sup>
 - [CableMatters Dual Display USB-C Docking Station 107008-BLK](https://www.cablematters.com/pc-881-127-cable-matters-60-ghz-wireless-docking-station-hybrid-model-with-usb-c.aspx) [[community-tested](https://github.com/system76/docs/pull/860) on an Intel system] <sup>1</sup>
-  - Outputting HDMI and DisplayPort simultaneously not tested.
-  - Multi-monitor daisy-chaining not tested.
-  - Audio not tested.
+  - Simultaneous HDMI/DisplayPort, DisplayPort daisy-chaining, and 3.5mm audio not tested.
 - [CalDigit TS3 Plus](https://www.caldigit.com/ts3-plus/) [community-tested on an [Intel system](https://github.com/system76/docs/pull/417) and an [NVIDIA system](https://github.com/system76/docs/pull/917)] <sup>1</sup>
   - Downstream (passthrough) Thunderbolt 3 port not tested.
   - May not be able to wake system using peripherals connected via dock.

--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -58,7 +58,7 @@ We have tested the following docks:
 Community members have reported that the following docks work with our products:
 
 - [Anker A8392](https://us.anker.com/products/a8392) [[community-tested](https://github.com/system76/docs/pull/797) on an Intel system] <sup>1</sup>
-- [CableMatters Dual Display USB-C Docking Station 107008-BLK](https://www.cablematters.com/pc-881-127-cable-matters-60-ghz-wireless-docking-station-hybrid-model-with-usb-c.aspx) [[community-tested](https://github.com/system76/docs/pull/860) on an Intel system] <sup>1</sup>
+- [CableMatters 107008-BLK](https://www.cablematters.com/pc-881-127-cable-matters-60-ghz-wireless-docking-station-hybrid-model-with-usb-c.aspx) [[community-tested](https://github.com/system76/docs/pull/860) on an Intel system] <sup>1</sup>
   - Simultaneous HDMI/DisplayPort, DisplayPort daisy-chaining, and 3.5mm audio not tested.
 - [CalDigit TS3 Plus](https://www.caldigit.com/ts3-plus/) [community-tested on an [Intel system](https://github.com/system76/docs/pull/417) and an [NVIDIA system](https://github.com/system76/docs/pull/917)] <sup>1</sup>
   - Downstream (passthrough) Thunderbolt 3 port not tested.

--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -58,6 +58,10 @@ We have tested the following docks:
 Community members have reported that the following docks work with our products:
 
 - [Anker A8392](https://us.anker.com/products/a8392) [[community-tested](https://github.com/system76/docs/pull/797) on an Intel system] <sup>1</sup>
+- [CableMatters Dual Display USB-C Docking Station 107008-BLK](https://www.cablematters.com/pc-881-127-cable-matters-60-ghz-wireless-docking-station-hybrid-model-with-usb-c.aspx) [[community-tested](todo) on an Intel system]
+  - Outputting HDMI and DisplayPort simultaneously not tested.
+  - Multi-monitor daisy-chaining not tested.
+  - Audio not tested.
 - [CalDigit TS3 Plus](https://www.caldigit.com/ts3-plus/) [community-tested on an [Intel system](https://github.com/system76/docs/pull/417) and an [NVIDIA system](https://github.com/system76/docs/pull/917)] <sup>1</sup>
   - Downstream (passthrough) Thunderbolt 3 port not tested.
   - May not be able to wake system using peripherals connected via dock.

--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -58,7 +58,7 @@ We have tested the following docks:
 Community members have reported that the following docks work with our products:
 
 - [Anker A8392](https://us.anker.com/products/a8392) [[community-tested](https://github.com/system76/docs/pull/797) on an Intel system] <sup>1</sup>
-- [CableMatters Dual Display USB-C Docking Station 107008-BLK](https://www.cablematters.com/pc-881-127-cable-matters-60-ghz-wireless-docking-station-hybrid-model-with-usb-c.aspx) [[community-tested](todo) on an Intel system]
+- [CableMatters Dual Display USB-C Docking Station 107008-BLK](https://www.cablematters.com/pc-881-127-cable-matters-60-ghz-wireless-docking-station-hybrid-model-with-usb-c.aspx) [[community-tested](https://github.com/system76/docs/pull/860) on an Intel system] <sup>1</sup>
   - Outputting HDMI and DisplayPort simultaneously not tested.
   - Multi-monitor daisy-chaining not tested.
   - Audio not tested.


### PR DESCRIPTION
Docking Station: CableMatters Dual Display USB-C Docking Station, model 107008-BLK.

https://www.cablematters.com/pc-881-127-cable-matters-60-ghz-wireless-docking-station-hybrid-model-with-usb-c.aspx

I use this docking station with my Lemur Pro (lemp10) to connect via DisplayPort to an external monitor (1920 x 1080), a gigabit Ethernet connection, as well as mouse/keyboard input through the USB-2 ports. It also supplies power to the computer (up to 60 W). No issues encountered during first 24 hours of use, and it worked out of the box. I did test the HDMI port initially and that also works. Suspending the laptop then waking from keyboard through the docking station works.

I have not tested data transfer over the USB-3 ports, but the power output on the USB-A port on the front does work.

I have not tested outputting HDMI and DisplayPort simultaneously.

I have not tested multi-monitor daisy-chaining.

I have not tested audio through the docking station at all.

Sidenote, CableMatters is my go-to for buying any kind of cable - their products are always up to standard and they seem to care about quality. I am pleasantly surprised they also produced a docking station.