### PR TITLE
Include nvme-cli

### DIFF
--- a/content/hardware-failure.md
+++ b/content/hardware-failure.md
@@ -45,7 +45,7 @@ All of the values start at 100, and work their way down to 0.  The terms "old-ag
 NVMe drives can't be checked with a SMART Test through the <u>Disks</u> application but the package <u>smartmontools</u> can be used for this. It can be installed with this command:
 
 ```bash
-sudo apt install smartmontools
+sudo apt install nvme-cli smartmontools
 ```
 
 First, let's list the NVMe's that are installed:


### PR DESCRIPTION
The `nvme` command referenced by the docs is provided by the `nvme-cli` pacakge:

```
kubuntu@kubuntu:~$ dpkg -S nvme | grep `which nvme`
nvme-cli: /usr/sbin/nvme
```