### PR TITLE
Remove Ubuntu PPA from Pop upgrade instructions

### DIFF
--- a/content/upgrade-pop.md
+++ b/content/upgrade-pop.md
@@ -175,7 +175,6 @@ sudo apt install pop-desktop
 ```bash
 sudo mkdir -p /etc/apt/backup
 sudo mv /etc/apt/sources.list.d/* /etc/apt/backup
-sudo apt-add-repository -yn ppa:system76-dev/stable
 sudo apt-add-repository -yn ppa:system76/pop
 sudo sed -i 's/old-releases/us.archive/g' /etc/apt/sources.list
 sudo sed -Ei 's/cosmic|eoan|disco|eoan/focal/g' /etc/apt/sources.list /etc/apt/sources.list.d/*.list


### PR DESCRIPTION
The `system76-dev/stable` PPA is only meant for Ubuntu, not Pop!_OS. In previous versions, having it added wouldn't cause any problems, as it would only provide packages that `system76/pop` also provides; however, now that Impish doesn't use Launchpad anymore, having this file left over can cause confusion.

(Further changes to this article would be needed to show the process to go from e.g. 20.10 to 21.10, but this PPA was not needed even for 20.04, which this section is referencing.)