### PR TITLE
Replace broken, general link with working, specific link; add missing commas

### DIFF
--- a/content/pop-incomplete-upgrade.md
+++ b/content/pop-incomplete-upgrade.md
@@ -201,10 +201,10 @@ After you have made the edit, save the file and start the upgrade again.
 
 ## If you are still not able to upgrade
 
-If the system is still not able to upgrade and you have a System76 system please open a support ticket and include this file:
+If the system is still not able to upgrade and you have a System76 system, please open a [support ticket](https://support.system76.com/) and include this file:
 
 ```bash
 journalctl -u pop-upgrade > ~/pop-upgrade.log
 ```
 
-If it is not a System76 system go to our Pop!\_OS Mattermost chat for community support [here](chat.pop-os.org).
+If it is not a System76 system, go to our Pop!\_OS Mattermost chat for community support [here](https://chat.pop-os.org/pop-os/channels/upgrade-help).

--- a/content/pop-incomplete-upgrade.md
+++ b/content/pop-incomplete-upgrade.md
@@ -201,7 +201,7 @@ After you have made the edit, save the file and start the upgrade again.
 
 ## If you are still not able to upgrade
 
-If the system is still not able to upgrade and you have a System76 system, please open a [support ticket](https://support.system76.com/) and include this file:
+If the system is still not able to upgrade and you have a System76 system, please open a [support ticket](https://system76.com/my-account/support-tickets/new) and include this file:
 
 ```bash
 journalctl -u pop-upgrade > ~/pop-upgrade.log


### PR DESCRIPTION
Fixes https://github.com/system76/docs/issues/872.

https://github.com/system76/docs/issues/872 was caused by the `https://` protocol missing from the link. This fix also makes the link more specific so it goes directly to the ~upgrade-help channel in the pop-os team, and adds a link to the support website for customers. It also adds a couple of missing commas in this section.