### PR TITLE
Fixing broken link

### DIFF
--- a/content/pop-basics.md
+++ b/content/pop-basics.md
@@ -198,4 +198,4 @@ The <u>Pop!_Shop</u> can be used to install additional software. Just search for
 
 ![Pop!_Shop](/images/pop-basics/pop-shop.png)
 
-To learn more about the Pop!_Shop refer to [this page](https://github.com/pop-os/shop), and for more information about package management in Pop!\_OS see this [article](articles/manage-repos-pop).
+To learn more about the Pop!_Shop refer to [this page](https://github.com/pop-os/shop), and for more information about package management in Pop!\_OS see this [article](https://support.system76.com/articles/manage-repos-pop/).

--- a/content/pop-basics.md
+++ b/content/pop-basics.md
@@ -198,4 +198,4 @@ The <u>Pop!_Shop</u> can be used to install additional software. Just search for
 
 ![Pop!_Shop](/images/pop-basics/pop-shop.png)
 
-To learn more about the Pop!_Shop refer to [this page](https://github.com/pop-os/shop), and for more information about package management in Pop!\_OS see this [article](https://support.system76.com/articles/manage-repos-pop/).
+To learn more about the Pop!_Shop refer to [this page](https://github.com/pop-os/shop), and for more information about package management in Pop!\_OS see this [article](/articles/manage-repos-pop/).


### PR DESCRIPTION
Relative link using `articles/manage-repos-pop` lead to the compounded and non-functional link below:

https://support.system76.com/articles/pop-basics/articles/manage-repos-pop

~Replaced the relative link with an absolute link~

Aaron updated and corrected the relative link.