### PR TITLE
Update for new install instructions.

### DIFF
--- a/content/tensorman.md
+++ b/content/tensorman.md
@@ -29,10 +29,10 @@ redirect_from:
 sudo apt install tensorman
 ```
 
-For NVIDIA CUDA support, the following package must be installed:
+For NVIDIA CUDA support, the following packages must be installed:
 
 ```bash
-sudo apt install nvidia-container-runtime
+sudo apt install nvidia-docker2 nvidia-container-toolkit
 ```
 
 The user account working with Tensorman must be added to the `docker` group if that hasn't been done already:
@@ -41,7 +41,13 @@ The user account working with Tensorman must be added to the `docker` group if t
 sudo usermod -aG docker $USER
 ```
 
-If Docker was just installed, then a reboot will be needed before Tensorman can be used.
+THe last thing is to add a kernel parameter:
+
+```bash
+sudo kernelstub --add-options "systemd.unified_cgroup_hierarchy=0"
+```
+
+and reboot. Then you are ready for liftoff!
 
 ## About Tensorman
 

--- a/content/tensorman.md
+++ b/content/tensorman.md
@@ -29,11 +29,11 @@ redirect_from:
 sudo apt install tensorman
 ```
 
-For NVIDIA CUDA support, the following packages must be installed:
+For NVIDIA CUDA support, install the following packages, depending on your Pop!_OS version:
 
-```bash
-sudo apt install nvidia-docker2
-```
+| Pop!_OS 21.10 +                    | Pop!_OS 20.04 LTS                            |
+| ---------------------------------- | -------------------------------------------- |
+| `sudo apt install nvidia-docker2`  | `sudo apt install nvidia-container-runtime`  |
 
 The user account working with Tensorman must be added to the `docker` group if that hasn't been done already:
 

--- a/content/tensorman.md
+++ b/content/tensorman.md
@@ -41,13 +41,13 @@ The user account working with Tensorman must be added to the `docker` group if t
 sudo usermod -aG docker $USER
 ```
 
-One last thing, we need to add a kernel parameter:
+The last step is to add a kernel parameter:
 
 ```bash
 sudo kernelstub --add-options "systemd.unified_cgroup_hierarchy=0"
 ```
 
-... and reboot. Then you are ready for liftoff!
+...and reboot. Then you're ready for liftoff!
 
 ## About Tensorman
 

--- a/content/tensorman.md
+++ b/content/tensorman.md
@@ -32,7 +32,7 @@ sudo apt install tensorman
 For NVIDIA CUDA support, the following packages must be installed:
 
 ```bash
-sudo apt install nvidia-docker2 nvidia-container-toolkit
+sudo apt install nvidia-docker2
 ```
 
 The user account working with Tensorman must be added to the `docker` group if that hasn't been done already:

--- a/content/tensorman.md
+++ b/content/tensorman.md
@@ -41,13 +41,13 @@ The user account working with Tensorman must be added to the `docker` group if t
 sudo usermod -aG docker $USER
 ```
 
-THe last thing is to add a kernel parameter:
+One last thing, we need to add a kernel parameter:
 
 ```bash
 sudo kernelstub --add-options "systemd.unified_cgroup_hierarchy=0"
 ```
 
-and reboot. Then you are ready for liftoff!
+... and reboot. Then you are ready for liftoff!
 
 ## About Tensorman
 


### PR DESCRIPTION
21.10+ has different requirements to install and run tensorman.