### PR TITLE
Specifying the whole DaVinci File name makeresolve

### DIFF
--- a/content/install-davinci-resolve.md
+++ b/content/install-davinci-resolve.md
@@ -51,16 +51,10 @@ Next, extract the MakeResolveDeb zip file into the same directory where the DaVi
 
 Open the DaVinci Resolve directory, right click on an empty space between/below the file icons, and select 'Open in Terminal.'
 
-In the new **Terminal** window, run this command if you are using the free-of-cost version of DaVinci Resolve:
+In the new **Terminal** window, run this command to use the MakeResolveDeb script on the DaVinci Resolve installer file:
 
 ```bash
-./makeresolvedeb*.sh //Whole DaVinci File. Example: DaVinci_Resolve_17.4.3_Linux.run
-```
-
-Or this command if you are using the paid Studio version of DaVinci Resolve:
-
-```bash
-./makeresolvedeb*.sh studio
+./makeresolvedeb*.sh DaVinci_Resolve_*_Linux.run
 ```
 
 Once the script finishes running and the terminal prompt returns, run this command to install DaVinci Resolve:

--- a/content/install-davinci-resolve.md
+++ b/content/install-davinci-resolve.md
@@ -51,7 +51,7 @@ Next, extract the MakeResolveDeb zip file into the same directory where the DaVi
 
 Open the DaVinci Resolve directory, right click on an empty space between/below the file icons, and select 'Open in Terminal.'
 
-In the new **Terminal** window, run this command to use the MakeResolveDeb script on the DaVinci Resolve installer file:
+In the new **Terminal** window, run this command to create an installable package for DaVinci Resolve:
 
 ```bash
 ./makeresolvedeb*.sh DaVinci_Resolve_*_Linux.run

--- a/content/install-davinci-resolve.md
+++ b/content/install-davinci-resolve.md
@@ -54,7 +54,7 @@ Open the DaVinci Resolve directory, right click on an empty space between/below 
 In the new **Terminal** window, run this command if you are using the free-of-cost version of DaVinci Resolve:
 
 ```bash
-./makeresolvedeb*.sh lite
+./makeresolvedeb*.sh //Whole DaVinci File. Example: DaVinci_Resolve_17.4.3_Linux.run
 ```
 
 Or this command if you are using the paid Studio version of DaVinci Resolve:


### PR DESCRIPTION
Using Lite or Studio doesn't work anymore at least for me. What I did try was running this command instead and it worked. ./makeresolvedeb*.sh DaVinci_Resolve_17.4.3_Linux.run