### PR TITLE
Fix broken "additional setup" link.

### DIFF
--- a/content/windows.md
+++ b/content/windows.md
@@ -339,7 +339,7 @@ After completing the wizard, Windows will display a slideshow while it finishes 
 
 ![Windows 10 desktop](/images/dual-booting/windows-10-desktop.jpg)
 
-See [additional setup](#additional-setup-for-windows) for next steps.
+See [additional setup](#additional-setup-for-windows-not-in-vm) for next steps.
 
 ---
 
@@ -462,7 +462,7 @@ After completing the wizard, Windows will display a slideshow while it finishes 
 
 ![Windows 10 desktop](/images/dual-booting/windows-10-desktop.jpg)
 
-See [additional setup](#additional-setup-for-windows) for next steps.
+See [additional setup](#additional-setup-for-windows-not-in-vm) for next steps.
 
 ---
 


### PR DESCRIPTION
The "additional setup" href at the end of both the shared drive and dedicated drive sections is missing the "-not-in-vm" portion of the ID for the relevant section (line 469).