### PR TITLE
Added line to tailwind.css for foldable headers.

### DIFF
--- a/assets/styles/tailwind.css
+++ b/assets/styles/tailwind.css
@@ -31,3 +31,10 @@
     @apply text-warm-gray-600 font-sans text-base leading-8 sm:text-lg sm:leading-9 xl:text-xl xl:leading-10;
   }
 }
+
+/*
+ * This block allows Markdown '#' headers to be made into foldable sections
+ */
+details summary > * {
+    display: inline;
+}


### PR DESCRIPTION
This PR adds a line to the `tailwind.css` stylesheet to allow the Markdown `#` headers to act as foldable sections.

Without the changes here, the folding `>` icon appears a line above the header's text.