### PR TITLE
internet connectivity before copying over resolv.conf - resolves issue #835

### DIFF
--- a/content/bootloader.md
+++ b/content/bootloader.md
@@ -83,6 +83,8 @@ Run these commands based on what type of disk you have:
 | ```sudo mount /dev/nvme0n1p2 /mnt```         | ```sudo mount /dev/sda2 /mnt```        |
 |```sudo mount /dev/nvme0n1p1 /mnt/boot/efi``` |```sudo mount /dev/sda1 /mnt/boot/efi```|
 
+>**Note**: Make sure the system has an internet connection before copying over /etc/resolv.conf file.
+
 ```bash
 for i in dev dev/pts proc sys run; do sudo mount -B /$i /mnt/$i; done
 sudo cp -n /etc/resolv.conf /mnt/etc/
@@ -107,6 +109,8 @@ Run these commands based on what type of disk you have:
 | NVMe Drive                           | SATA Drive                      |
 | :----------------------------------- | :------------------------------ |
 | ```sudo mount /dev/nvme0n1p2 /mnt``` | ```sudo mount /dev/sda2 /mnt``` |
+
+>**Note**: Make sure the system has an internet connection before copying over /etc/resolv.conf file.
 
 ```bash
 for i in dev dev/pts proc sys run; do sudo mount -B /$i /mnt/$i; done
@@ -141,6 +145,8 @@ Run these commands based on what type of disk you have:
 | :-------------------------------------------- | :-------------------------------------- |
 | ```sudo mount /dev/nvme0n1p3 /mnt```          | ```sudo mount /dev/sda3 /mnt```         |
 | ```sudo mount /dev/nvme0n1p1 /mnt/boot/efi``` | ```sudo mount /dev/sda1 /mnt/boot/efi```|
+
+>**Note**: Make sure the system has an internet connection before copying over /etc/resolv.conf file.
 
 ```bash
 for i in dev dev/pts proc sys run; do sudo mount -B /$i /mnt/$i; done

--- a/content/login-from-live-disk.md
+++ b/content/login-from-live-disk.md
@@ -21,9 +21,9 @@ tableOfContents: true
 
 ## Login from Live Disk (Chroot)
 
-It is possible to mount an OS drive and log into the installed OS with root access. This is called gaining "chroot" (change to root) access. This process is used for a variety of things. [rescuing files](/articles/disaster-recovery), [fixing package manager issues](/articles/package-manager-pop), [resetting forgotten user passwords](/articles/password), etc.
+It is possible to mount an OS drive and log into the installed OS with root access. This is called gaining "chroot" (change to root) access. This process is useful when [rescuing files](/articles/disaster-recovery), [fixing package manager issues](/articles/package-manager-pop), or [resetting forgotten user passwords](/articles/password).
 
-You'll need a Live OS Environment from which to mount your drive, and log in. This can be done from a [live USB](/articles/live-disk), or, on Pop!_OS, from the [recovery partition](/articles/pop-recovery).
+You'll need a Live OS Environment from which to mount your drive, and log in. This can be done from a [live USB](/articles/live-disk), or on Pop!_OS from the [recovery partition](/articles/pop-recovery).
 Boot the computer while holding down the [boot menu key for your system](/articles/boot-menu), or the <kbd>SPACE</kbd> bar to access Systemd, and the Pop!\_OS Recovery partition.
 
 Once booted into the Live Environment, press <kbd>SUPER</kbd>+<kbd>T</kbd> to open a terminal (Pop!\_OS), or <kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>T</kbd> (Ubuntu) then type this command:
@@ -34,7 +34,7 @@ lsblk
 
 This will show you the name of the main internal drive, which will have 4 partitions (Pop!\_OS), or 3 (Ubuntu) on it.  We will be working with the 3rd partition.  If the main drive is an NVMe drive, it will be called `/dev/nvme0n1p3` (p2 on Ubuntu) and if the drive is a SATA or regular M.2 drive, it will be called `/dev/sda3` (sda2 on Ubuntu).
 
-**NOTE:** The rest of these instructions assume a Pop!\_OS install, for partition labelling. The instructions are otherwise the same. Change the partition number accordingly.
+>**Note:** The rest of these instructions assume a Pop!\_OS install, for partition labelling. The instructions are otherwise the same. Change the partition number accordingly.
 
 Next, run this command:
 
@@ -57,7 +57,7 @@ sudo lvscan
 sudo vgchange -ay
 ```
 
-**Note:** Pay attention to what the `cryptdata` group is called. If it is named something other than `data-root`, substitute the correct info into this next command.  Make sure that `-root` is on the end:
+>**Note:** Pay attention to what the `cryptdata` group is called. If it is named something other than `data-root`, substitute the correct info into this next command.  Make sure that `-root` is on the end:
 
 ```bash
 sudo mount /dev/mapper/data-root /mnt
@@ -74,6 +74,8 @@ The EFI partition is the next partition to be mounted. To help identify it, this
 | **SATA Drives**                       | **NVMe Drives**                          |
 |:-------------------------------------:|:----------------------------------------:|
 | ```sudo mount /dev/sda1 /mnt/boot/efi```    | ```sudo mount /dev/nvme0n1p1 /mnt/boot/efi```  |
+
+>**Note**: Make sure the system has an internet connection before copying over /etc/resolv.conf file.
 
 ```bash
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done

--- a/content/pop-recovery.md
+++ b/content/pop-recovery.md
@@ -23,7 +23,7 @@ The Recovery Partition is a full copy of the Pop!\_OS installation disk. It can 
 
 To boot into recovery mode, bring up the <u>systemd-boot</u> menu by holding down <kbd>SPACE</kbd> while the system is booting, or by holding/tapping any function keys **NOT** used to [Access the BIOS/Boot Menu](/articles/boot-menu) (On non-System76 hardware, try the keys <kbd>F1</kbd> through <kbd>F12</kbd>).
 
- **NOTE:** These instructions assume Pop!\_OS is the only OS running on your system. If you are booting more than one operating system you may need to change your boot order first, or manually select the Pop!\_OS Disk from your BIOS/Boot menu.
+ >**Note:** These instructions assume Pop!\_OS is the only OS running on your system. If you are booting more than one operating system you may need to change your boot order first, or manually select the Pop!\_OS Disk from your BIOS/Boot menu.
 
 Once the menu is shown, choose **Pop!_OS Recovery**.
 
@@ -35,14 +35,13 @@ This option erases the current install along with all user files. It reformats t
 
 Steps to back up user-files from a Live Disk/Recovery can be found [here](https://support.system76.com/articles/disaster-recovery).
 
-**NOTE:**
-The Recovery partition OS version will either be the same as the OS version that shipped with your computer or whichever version to which the Recovery partition has been [updated](#update-recovery-partition).
+>**Note:**The Recovery partition OS version will either be the same as the OS version that shipped with your computer or whichever version to which the Recovery partition has been [updated](#update-recovery-partition).
 
 ## Refresh Install
 
 The Refresh Install option allows you to reinstall the OS without losing user account information and data in the home directory.
 
-**NOTE:** user-installed applications are not preserved and will need to be reinstalled.
+>**Note:** User-installed applications are not preserved and will need to be reinstalled.
 
 If the `Refresh Install` option is not present on the install screen, one of two things may be true.
 
@@ -62,9 +61,9 @@ If the existing install is encrypted, please see the [encrypted disk](#encrypted
 
 If the existing OS install needs to be repaired, the installer application should be closed. An app menu is located in the top-left of the screen with the name of the currently running application (in this case: "Install Pop!\_OS"). Click on the app menu and select `Quit`. Alternatively, you can use the installer app to select keyboard and language settings, and then click the `Try Demo Mode` button in the lower-left corner of the install page.
 
-**NOTE:** be sure not to choose any install or repair options, as this could result in data loss.
+>**Note:** Do not choose any install or repair options, as this could result in data loss.
 
-To access the existing OS drive follow the instructions below.
+For the instructions below to access the existing OS drive:
 
 First, press <kbd>SUPER</kbd>+<kbd>T</kbd> to open a terminal, then type this command:
 
@@ -105,13 +104,15 @@ And now the existing hard drive can be accessed by going to the `/mnt` folder.  
 
 ## Chroot
 
-`chroot` is the way to run commands as if the existing operating system had been booted.  Once these commands are run, then package manager (`apt`) and other system-level commands can be run.
+`chroot` runs commands as if the existing operating system had been booted.  Once these commands are run, then package manager (`apt`) and other system-level commands can be run.
 
 The EFI partition is the next partition to be mounted. To help identify it, this partition is usually around 512MB, and is labeled as `/boot/efi`.
 
 | **SATA Drives**                       | **NVMe Drives**                          |
 |:-------------------------------------:|:----------------------------------------:|
 | ```sudo mount /dev/sda1 /mnt/boot/efi```    | ```sudo mount /dev/nvme0n1p1 /mnt/boot/efi```  |
+
+>**Note**: Make sure the system has an internet connection before copying over /etc/resolv.conf file.
 
 ```bash
 for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done


### PR DESCRIPTION
This PR does the following: 

Adds a note informing the reader to connect to the internet before copying over the /etc/resolv.conf file while in chroot. I've also made some minor wording and punctuation changes.

How should we standardize capitalization of these items?
- systemd (Systemd, SystemD, etc - wikipedia says systemd)
- chroot (I've seen CHROOT and Chroot in our documentation)