### PR TITLE
Update libssl package name for DaVinci Resolve installation

### DIFF
--- a/content/install-davinci-resolve.md
+++ b/content/install-davinci-resolve.md
@@ -24,7 +24,7 @@ DaVinci Resolve requires an NVIDIA GPU to run. (Intel GPUs lack the necessary Op
 The following packages will be needed to build and install DaVinci Resolve:
 
 ```bash
-sudo apt install libssl1.1 ocl-icd-opencl-dev fakeroot xorriso
+sudo apt install libssl3 ocl-icd-opencl-dev fakeroot xorriso
 ```
 
 ### Download DaVinci Resolve and the MakeResolveDeb script


### PR DESCRIPTION
The name of this package has changed in 22.04 LTS.