### PR TITLE
fixing broken link to `manage-repos-pop`

### DIFF
--- a/content/software-triage.md
+++ b/content/software-triage.md
@@ -129,7 +129,7 @@ Sources:
 
 [Fix Package Manager](/articles/package-manager-pop)
 
-[Manage Repositories](/articles/manage-repos-pop.md)
+[Manage Repositories](/articles/manage-repos-pop)
 
 ### 4. Test Second Admin User
 


### PR DESCRIPTION
The link from `software-triage` to `manage-repos-pop` was broken, as it had an `.md` extension in the URL. Broken link was reported by a customer.