### PR TITLE
Update Bluetooth troubleshooting commands for v22.04

### DIFF
--- a/content/bluetooth.md
+++ b/content/bluetooth.md
@@ -75,9 +75,11 @@ Bluetooth issues can be troubleshooted in several ways.  The first thing to chec
 Then, try reinstalling Bluetooth related software with this command, depending on the verison of Pop!\_OS you're using.
 
 *For Pop!\_OS 22.04 or higher:*
+
 ```bash
 sudo apt reinstall --purge bluez gnome-bluetooth
 ```
+
 *For Pop!\_OS 21.10 or 20.04:*
 
 ```bash
@@ -131,6 +133,7 @@ sudo rfkill unblock all
 This will check to see Bluetooth is blocked, and if so, unblock it.
 
 *For Pop!\_OS 21.10 or 20.04:*
+
 ```bash
 pactl load-module module-bluetooth-discover
 ```

--- a/content/bluetooth.md
+++ b/content/bluetooth.md
@@ -72,7 +72,13 @@ This process lowers the sound quality of the stream when in HSP/HFP mode, so aud
 
 Bluetooth issues can be troubleshooted in several ways.  The first thing to check is toggling airplane mode which will sometimes get Bluetooth functioning again.  Next, make sure Bluetooth is enabled in the top bar, or in the <u>Bluetooth</u> system settings.
 
-Then, try reinstalling Bluetooth related software with this command:
+Then, try reinstalling Bluetooth related software with this command, depending on the verison of Pop!OS you're using.
+
+*For Pop!OS v22.04 or higher:*
+```bash
+sudo apt reinstall --purge bluez gnome-bluetooth
+```
+*For Pop!OS v21.10 or v20.04:*
 
 ```bash
 sudo apt install --reinstall bluez gnome-bluetooth indicator-bluetooth pulseaudio-module-bluetooth
@@ -124,11 +130,12 @@ sudo rfkill unblock all
 
 This will check to see Bluetooth is blocked, and if so, unblock it.
 
+*For Pop!OS v21.10 or v20.04:*
 ```bash
 pactl load-module module-bluetooth-discover
 ```
 
-This will load the PulseAudio module responsible for Bluetooth Audio.  Typically, it's loaded by default, but sometimes a manual loading can get Bluetooth headsets working again.
+This will load the PulseAudio module responsible for Bluetooth Audio.  Typically, it's loaded by default, but sometimes a manual loading can get Bluetooth headsets working again. This module is no longer used on Pop!OS v22.04 or higher.
 
 ```bash
 sudo btmon

--- a/content/bluetooth.md
+++ b/content/bluetooth.md
@@ -130,12 +130,12 @@ sudo rfkill unblock all
 
 This will check to see Bluetooth is blocked, and if so, unblock it.
 
-*For Pop!\_OS v21.10 or v20.04:*
+*For Pop!\_OS 21.10 or 20.04:*
 ```bash
 pactl load-module module-bluetooth-discover
 ```
 
-This will load the PulseAudio module responsible for Bluetooth Audio.  Typically, it's loaded by default, but sometimes a manual loading can get Bluetooth headsets working again. This module is no longer used on Pop!\_OS v22.04 or higher.
+This will load the PulseAudio module responsible for Bluetooth Audio.  Typically, it's loaded by default, but sometimes a manual loading can get Bluetooth headsets working again. This module is no longer used on Pop!\_OS 22.04 or higher.
 
 ```bash
 sudo btmon

--- a/content/bluetooth.md
+++ b/content/bluetooth.md
@@ -74,11 +74,11 @@ Bluetooth issues can be troubleshooted in several ways.  The first thing to chec
 
 Then, try reinstalling Bluetooth related software with this command, depending on the verison of Pop!\_OS you're using.
 
-*For Pop!\_OS v22.04 or higher:*
+*For Pop!\_OS 22.04 or higher:*
 ```bash
 sudo apt reinstall --purge bluez gnome-bluetooth
 ```
-*For Pop!\_OS v21.10 or v20.04:*
+*For Pop!\_OS 21.10 or 20.04:*
 
 ```bash
 sudo apt install --reinstall bluez gnome-bluetooth indicator-bluetooth pulseaudio-module-bluetooth

--- a/content/bluetooth.md
+++ b/content/bluetooth.md
@@ -72,13 +72,13 @@ This process lowers the sound quality of the stream when in HSP/HFP mode, so aud
 
 Bluetooth issues can be troubleshooted in several ways.  The first thing to check is toggling airplane mode which will sometimes get Bluetooth functioning again.  Next, make sure Bluetooth is enabled in the top bar, or in the <u>Bluetooth</u> system settings.
 
-Then, try reinstalling Bluetooth related software with this command, depending on the verison of Pop!OS you're using.
+Then, try reinstalling Bluetooth related software with this command, depending on the verison of Pop!\_OS you're using.
 
-*For Pop!OS v22.04 or higher:*
+*For Pop!\_OS v22.04 or higher:*
 ```bash
 sudo apt reinstall --purge bluez gnome-bluetooth
 ```
-*For Pop!OS v21.10 or v20.04:*
+*For Pop!\_OS v21.10 or v20.04:*
 
 ```bash
 sudo apt install --reinstall bluez gnome-bluetooth indicator-bluetooth pulseaudio-module-bluetooth
@@ -130,12 +130,12 @@ sudo rfkill unblock all
 
 This will check to see Bluetooth is blocked, and if so, unblock it.
 
-*For Pop!OS v21.10 or v20.04:*
+*For Pop!\_OS v21.10 or v20.04:*
 ```bash
 pactl load-module module-bluetooth-discover
 ```
 
-This will load the PulseAudio module responsible for Bluetooth Audio.  Typically, it's loaded by default, but sometimes a manual loading can get Bluetooth headsets working again. This module is no longer used on Pop!OS v22.04 or higher.
+This will load the PulseAudio module responsible for Bluetooth Audio.  Typically, it's loaded by default, but sometimes a manual loading can get Bluetooth headsets working again. This module is no longer used on Pop!\_OS v22.04 or higher.
 
 ```bash
 sudo btmon

--- a/package-lock.json
+++ b/package-lock.json
@@ -2424,7 +2424,6 @@
         "fs-extra": "^10.0.0",
         "hasha": "^5.2.2",
         "image-meta": "^0.0.1",
-        "ipx": "^0.8.0",
         "is-https": "^4.0.0",
         "lru-cache": "^6.0.0",
         "node-fetch": "^2.6.1",
@@ -2885,9 +2884,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4006,7 +4002,6 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.2",
-        "prettier": "^1.18.2",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },
@@ -5634,7 +5629,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -8734,7 +8728,6 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "dependencies": {
-        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -19848,10 +19841,8 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -19929,7 +19920,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",


### PR DESCRIPTION
Some of the instructions on this document no longer apply for Pop!OS v22.04, so I've split up those commands into a version for v22.04 and a verison for previous releases. I also added a note to the section about the `module-bluetooth-discover` Pulseaudio module, which is no longer used in v22.04.