### PR TITLE
Add commands to clear wireplumber saved settings

### DIFF
--- a/content/audio.md
+++ b/content/audio.md
@@ -153,6 +153,8 @@ rm -r ~/.config/pulse/*
 rm -r ~/.local/state/wireplumber/*
 ```
 
+**NOTE:** When running those commands you may see messages similar to this: `rm: cannot remove '/home/ckw/.config/pulse/*': No such file or directory` those are safe to ignore as the file simply does not exist. 
+
 ### Audio crackling or hardware clicking
 
 If you hear audio crackling (especially when you start or stop playing audio), PulseAudio may be putting your audio card to sleep too often. This is known to happen on the [serw12](/articles/serval-dac/) and some [Thunderbolt docks](https://github.com/system76/docs/issues/491).

--- a/content/audio.md
+++ b/content/audio.md
@@ -153,7 +153,7 @@ rm -r ~/.config/pulse/*
 rm -r ~/.local/state/wireplumber/*
 ```
 
-**NOTE:** When running those commands you may see messages similar to this: `rm: cannot remove '/home/ckw/.config/pulse/*': No such file or directory` those are safe to ignore as the file simply does not exist. 
+**NOTE:** When running those commands you may see messages similar to this: `rm: cannot remove '/home/ckw/.config/pulse/*': No such file or directory` those are safe to ignore as the file simply does not exist.
 
 ### Audio crackling or hardware clicking
 

--- a/content/audio.md
+++ b/content/audio.md
@@ -149,9 +149,11 @@ pw-top
 Some particular problems may be solved by tweaks to ALSA or PulseAudio configuration. Clearing the current settings for Pipewire or PulseAudio may allow the defaults to be used again. To revert to defaults and clear any current saved settings run the following commands:
 
 ```
-rm -rn ~/.config/pulse/*
-rm -rn ~/.local/state/wireplumber/*
+rm -r ~/.config/pulse/*
+rm -r ~/.local/state/wireplumber/*
 ```
+
+**NOTE:** When running those commands you may see messages similar to this: `rm: cannot remove '/home/ckw/.config/pulse/*': No such file or directory` those are safe to ignore as the file simply does not exist.
 
 ### Audio crackling or hardware clicking
 

--- a/content/audio.md
+++ b/content/audio.md
@@ -146,7 +146,12 @@ pw-top
 
 ## Configuration Tweaks
 
-Some particular problems may be solved by tweaks to ALSA or PulseAudio configuration.
+Some particular problems may be solved by tweaks to ALSA or PulseAudio configuration. Clearing the current settings for Pipewire or PulseAudio may allow the defualts to be used again. To revert to defaults and clear any current saved settings run the following commands:
+
+```
+rm -r ~/.config/pulse/*
+rm -r ~/.local/state/wireplumber/*
+```
 
 ### Audio crackling or hardware clicking
 

--- a/content/audio.md
+++ b/content/audio.md
@@ -146,14 +146,12 @@ pw-top
 
 ## Configuration Tweaks
 
-Some particular problems may be solved by tweaks to ALSA or PulseAudio configuration. Clearing the current settings for Pipewire or PulseAudio may allow the defualts to be used again. To revert to defaults and clear any current saved settings run the following commands:
+Some particular problems may be solved by tweaks to ALSA or PulseAudio configuration. Clearing the current settings for Pipewire or PulseAudio may allow the defaults to be used again. To revert to defaults and clear any current saved settings run the following commands:
 
 ```
-rm -r ~/.config/pulse/*
-rm -r ~/.local/state/wireplumber/*
+rm -rn ~/.config/pulse/*
+rm -rn ~/.local/state/wireplumber/*
 ```
-
-**NOTE:** When running those commands you may see messages similar to this: `rm: cannot remove '/home/ckw/.config/pulse/*': No such file or directory` those are safe to ignore as the file simply does not exist.
 
 ### Audio crackling or hardware clicking
 


### PR DESCRIPTION
expand section to clear current saved settings for PulseAudio and Wireplumber