### PR TITLE
Add oryp9, lemp11, darp8, and gaze17

### DIFF
--- a/content/open-firmware-systems.md
+++ b/content/open-firmware-systems.md
@@ -39,14 +39,18 @@ The source code for our Open EC can be found [here](https://github.com/system76/
 |:------:|:-------------:|:-------:|
 | addw2  | Yes\*         | Yes\*   |
 | bonw14 | Yes           | Yes     |
+| darp8  | Yes           | Yes     |
 | darp7  | Yes           | Yes     |
 | darp6  | Yes           | Yes\*   |
 | galp5  | Yes           | Yes     |
 | galp4  | Yes           | No      |
+| gaze17 | Yes           | Yes     |
 | gaze16 | Yes           | Yes     |
 | gaze15 | Yes\*         | Yes\*   |
+| lemp11 | Yes           | Yes     |
 | lemp10 | Yes           | Yes     |
 | lemp9  | Yes           | Yes     |
+| oryp9  | Yes           | Yes     |
 | oryp8  | Yes           | Yes     |
 | oryp7  | Yes           | Yes     |
 | oryp6  | Yes           | Yes     |


### PR DESCRIPTION
This adds these models to the list of Open Firmware and Open EC per @crawfxrd .