### PR TITLE
Update Arch sections

### DIFF
--- a/content/system76-driver.md
+++ b/content/system76-driver.md
@@ -80,11 +80,31 @@ The support team typically makes a best-effort attempt to offer direction or tro
 
 ### Arch - Manual install
 
-First, install some build dependencies for the the <u>System76 Firmware Daemon</u> and <u>System76 Driver</u> packages:
+First, install some build dependencies for the the <u>System76 Firmware Daemon</u>, <u>System76 Driver</u> and the <u>Firmware Manager</u> packages:
 
 ```bash
 sudo pacman -S --needed base-devel git linux-headers
 ```
+
+Next import Jeremy Sollar's public key which is needed to build the <u>System76 Driver</u>
+
+```bash
+gpg --recv-keys 87F211AF2BE4C2FE
+```
+
+### System76 Firmware Daemon
+
+These commands will clone, build and install the <u>System76 Firmware Daemon</u> service.
+
+```bash
+git clone https://aur.archlinux.org/system76-firmware-daemon.git
+cd system76-firmware-daemon
+makepkg -srcif
+sudo systemctl enable --now system76-firmware-daemon
+sudo gpasswd -a $USER adm
+```
+
+### System76 Driver
 
 Next, the <u>System76 Driver</u> package can be cloned, built, and installed using these commands:
 
@@ -94,6 +114,18 @@ cd system76-driver
 makepkg -srcif
 sudo systemctl enable --now system76
 ```
+
+### System76 Firmware Manager
+
+These commands will clone, build and install the <u>System76 Firmware Manager</u> application.
+
+```bash
+git clone https://aur.archlinux.org/firmware-manager.git
+cd firmware-manager
+makepkg -srcif
+```
+
+Now reboot the system so that our user is added to the `adm` group then we are done!
 
 ### Arch - Using an AUR helper
 
@@ -106,6 +138,16 @@ makepkg -si
 ```
 
 **Note:** By default, <u>Paru</u> uses VIM keyboard shortcuts, so when you see a `:`, press the <kbd>q</kbd> key to continue. You may also need to confirm the import of some public keys using the <kbd>y</kbd> key.
+
+```bash
+paru -s system76-firmware-daemon
+sudo systemctl enable --now system76-firmware-daemon
+sudo gpasswd -a $USER adm
+```
+
+```bash
+paru -s firmware-manager
+```
 
 ```bash
 paru -s system76-driver

--- a/content/system76-driver.md
+++ b/content/system76-driver.md
@@ -86,12 +86,6 @@ First, install some build dependencies for the <u>System76 Firmware Daemon</u>, 
 sudo pacman -S --needed base-devel git linux-headers
 ```
 
-Next import Jeremy Soller's public key which is needed to build the <u>System76 Driver</u>
-
-```bash
-gpg --recv-keys 87F211AF2BE4C2FE
-```
-
 ### System76 Firmware Daemon
 
 These commands will clone, build and install the <u>System76 Firmware Daemon</u> service.

--- a/content/system76-driver.md
+++ b/content/system76-driver.md
@@ -104,6 +104,16 @@ sudo systemctl enable --now system76-firmware-daemon
 sudo gpasswd -a $USER adm
 ```
 
+### System76 Firmware Manager
+
+These commands will clone, build and install the <u>System76 Firmware Manager</u> application.
+
+```bash
+git clone https://aur.archlinux.org/firmware-manager.git
+cd firmware-manager
+makepkg -srcif
+```
+
 ### System76 Driver
 
 Next, the <u>System76 Driver</u> package can be cloned, built, and installed using these commands:
@@ -113,16 +123,6 @@ git clone https://aur.archlinux.org/system76-driver.git
 cd system76-driver
 makepkg -srcif
 sudo systemctl enable --now system76
-```
-
-### System76 Firmware Manager
-
-These commands will clone, build and install the <u>System76 Firmware Manager</u> application.
-
-```bash
-git clone https://aur.archlinux.org/firmware-manager.git
-cd firmware-manager
-makepkg -srcif
 ```
 
 Now reboot the system so that our user is added to the `adm` group then we are done!

--- a/content/system76-driver.md
+++ b/content/system76-driver.md
@@ -80,13 +80,13 @@ The support team typically makes a best-effort attempt to offer direction or tro
 
 ### Arch - Manual install
 
-First, install some build dependencies for the the <u>System76 Firmware Daemon</u>, <u>System76 Driver</u> and the <u>Firmware Manager</u> packages:
+First, install some build dependencies for the <u>System76 Firmware Daemon</u>, <u>System76 Driver</u> and the <u>Firmware Manager</u> packages:
 
 ```bash
 sudo pacman -S --needed base-devel git linux-headers
 ```
 
-Next import Jeremy Sollar's public key which is needed to build the <u>System76 Driver</u>
+Next import Jeremy Soller's public key which is needed to build the <u>System76 Driver</u>
 
 ```bash
 gpg --recv-keys 87F211AF2BE4C2FE
@@ -125,11 +125,11 @@ makepkg -srcif
 sudo systemctl enable --now system76
 ```
 
-Now reboot the system so that our user is added to the `adm` group then we are done!
+Reboot the system so that our user is added to the `adm` group, then we are done!
 
 ### Arch - Using an AUR helper
 
-Arch uesrs can alternatively use an AUR helper to automate some of the steps for installation and upgrading; in this example, we'll use the <u>Paru</u> application. <u>Paru</u> can be installed from the AUR using these commands:
+Arch users can alternatively use an AUR helper to automate some of the steps for installation and upgrading; in this example, we'll use the <u>Paru</u> application. <u>Paru</u> can be installed from the AUR using these commands:
 
 ```bash
 git clone https://aur.archlinux.org/paru.git

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -37,38 +37,6 @@ This command will install all of the packages using <u>Paru</u>.
 paru -S system76-firmware-daemon system76-firmware firmware-manager system76-power gnome-shell-extension-system76-power-git system76-driver system76-dkms system76-acpi-dkms
 ```
 
-### System76 Firmware Daemon in Arch
-
-These commands will clone, build and install the <u>System76 Firmware Daemon</u> service.
-
-```bash
-git clone https://aur.archlinux.org/system76-firmware.git
-cd system76-firmware-daemon
-makepkg -srcif
-sudo systemctl enable --now system76-firmware-daemon
-sudo gpasswd -a $USER adm
-```
-
-These commands will install `system76-firmware-daemon` using <u>Paru</u>.
-
-**NOTE:** choose the first software option after running the <u>Paru</u> command.
-
-```bash
-paru -s system76-firmware-daemon
-sudo systemctl enable --now system76-firmware-daemon
-sudo gpasswd -a $USER adm
-```
-
-### System76 Firmware Manager in Arch
-
-These commands will clone, build and install the <u>System76 Firmware Manager</u> application.
-
-```bash
-git clone https://aur.archlinux.org/firmware-manager.git
-cd firmware-manager
-makepkg -srcif
-```
-
 This command will install `firmware-manager` using <u>Paru</u>.
 
 **NOTE:** choose the first software option after running the <u>Paru</u> command.
@@ -77,7 +45,7 @@ This command will install `firmware-manager` using <u>Paru</u>.
 paru -s firmware-manager
 ```
 
-### System76 DKMS in Arch
+### System76 DKMS
 
 This package is needed for hotkeys and fan(s) on Closed Firmware systems.
 
@@ -95,7 +63,7 @@ This command will install `system76-dkms` using <u>Paru</u>.
 paru -s system76-dkms
 ```
 
-### System76 ACPI DKMS in Arch
+### System76 ACPI DKMS
 
 This package is needed for hotkeys and fan(s) on Open Firmware systems.
 
@@ -113,7 +81,7 @@ This command will install `system76-acpi-dkms` using <u>Paru</u>.
 paru -s system76-acpi-dkms
 ```
 
-### System76 Power in Arch
+### System76 Power
 
 ```bash
 git clone https://aur.archlinux.org/system76-power.git
@@ -133,7 +101,7 @@ sudo systemctl enable --now system76-power
 sudo gpasswd -a $USER adm
 ```
 
-### System76 Power GNOME Shell Extension in Arch
+### System76 Power GNOME Shell Extension 
 
 ```bash
 git clone https://aur.archlinux.org/gnome-shell-extension-system76-power-git.git
@@ -149,7 +117,7 @@ This command will install `gnome-shell-extension-system76-power` using <u>Paru</
 paru -s gnome-shell-extension-system76-power
 ```
 
-### System76 Thelio Io DKMS in Arch
+### System76 Thelio Io DKMS 
 
 ```bash
 git clone https://aur.archlinux.org/system76-io-dkms.git
@@ -167,7 +135,7 @@ paru -s system76-io-dkms
 
 **NOTE:** This package is only needed for Thelio desktops.
 
-### System76 OLED in Arch
+### System76 OLED 
 
 ```bash
 git clone https://aur.archlinux.org/system76-oled.git

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -101,7 +101,7 @@ sudo systemctl enable --now com.System76.PowerDaemon.service
 sudo gpasswd -a $USER adm
 ```
 
-### System76 Power GNOME Shell Extension 
+### System76 Power GNOME Shell Extension
 
 ```bash
 git clone https://aur.archlinux.org/gnome-shell-extension-system76-power-git.git
@@ -117,7 +117,7 @@ This command will install `gnome-shell-extension-system76-power` using <u>Paru</
 paru -s gnome-shell-extension-system76-power
 ```
 
-### System76 Thelio Io DKMS 
+### System76 Thelio Io DKMS
 
 ```bash
 git clone https://aur.archlinux.org/system76-io-dkms.git
@@ -135,7 +135,7 @@ paru -s system76-io-dkms
 
 **NOTE:** This package is only needed for Thelio desktops.
 
-### System76 OLED 
+### System76 OLED
 
 ```bash
 git clone https://aur.archlinux.org/system76-oled.git

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -87,7 +87,7 @@ paru -s system76-acpi-dkms
 git clone https://aur.archlinux.org/system76-power.git
 cd system76-power
 makepkg -srcif
-sudo systemctl enable --now system76-power
+sudo systemctl enable --now com.System76.PowerDaemon.service
 sudo gpasswd -a $USER adm
 ```
 
@@ -97,7 +97,7 @@ These commands will install `system76-power` using <u>Paru</u>.
 
 ```bash
 paru -s system76-power
-sudo systemctl enable --now system76-power
+sudo systemctl enable --now com.System76.PowerDaemon.service
 sudo gpasswd -a $USER adm
 ```
 


### PR DESCRIPTION
This PR does the following:

- Updates the steps for adding system76-driver and other software
- Moves sections between articles as the driver depends on the system76-firmware package now 
- Adds section to add Jeremy's public key to build our software as it seems to be needed currently