### PR TITLE
feat: Update DAC crackling instructions for PipeWire

### DIFF
--- a/content/audio.md
+++ b/content/audio.md
@@ -159,7 +159,7 @@ rm -r ~/.local/state/wireplumber/*
 
 If you hear audio crackling (especially when you start or stop playing audio), your audio card may be going to sleep too often. This is known to happen on some versions of the [Serval WS](/articles/serval-dac/) and some [Thunderbolt docks](https://github.com/system76/docs/issues/491).
 
-#### Prevent Crackling with PipeWire/WirePlumber:
+#### Prevent Crackling with PipeWire/WirePlumber
 
 For Pop!_OS 22.04 and newer (and other distributions using PipeWire with WirePlumber), these two commands will disable this behavior and restart PipeWire:
 
@@ -175,7 +175,7 @@ sudo sed -i 's/\["session.suspend-timeout-seconds"\] = 0/--\["session.suspend-ti
 systemctl restart --user pipewire.service
 ```
 
-#### Prevent Crackling with PulseAudio:
+#### Prevent Crackling with PulseAudio
 
 For older versions of Pop!_OS or distributions using PulseAudio without PipeWire, these two commands will disable this behavior and restart PulseAudio:
 

--- a/content/audio.md
+++ b/content/audio.md
@@ -157,18 +157,36 @@ rm -r ~/.local/state/wireplumber/*
 
 ### Audio crackling or hardware clicking
 
-If you hear audio crackling (especially when you start or stop playing audio), PulseAudio may be putting your audio card to sleep too often. This is known to happen on the [serw12](/articles/serval-dac/) and some [Thunderbolt docks](https://github.com/system76/docs/issues/491).
+If you hear audio crackling (especially when you start or stop playing audio), your audio card may be going to sleep too often. This is known to happen on some versions of the [Serval WS](/articles/serval-dac/) and some [Thunderbolt docks](https://github.com/system76/docs/issues/491).
 
-These two commands will disable this behavior and restart PulseAudio:
+#### Prevent Crackling with PipeWire/WirePlumber:
 
+For Pop!_OS 22.04 and newer (and other distributions using PipeWire with WirePlumber), these two commands will disable this behavior and restart PipeWire:
+
+```bash
+sudo sed -i 's/--\["session.suspend-timeout-seconds"\] = 5/\["session.suspend-timeout-seconds"\] = 0/' /usr/share/wireplumber/main.lua.d/50-alsa-config.lua
+systemctl restart --user pipewire.service
 ```
+
+This change can be undone using these commands:
+
+```bash
+sudo sed -i 's/\["session.suspend-timeout-seconds"\] = 0/--\["session.suspend-timeout-seconds"\] = 5/' /usr/share/wireplumber/main.lua.d/50-alsa-config.lua
+systemctl restart --user pipewire.service
+```
+
+#### Prevent Crackling with PulseAudio:
+
+For older versions of Pop!_OS or distributions using PulseAudio without PipeWire, these two commands will disable this behavior and restart PulseAudio:
+
+```bash
 sudo sed -i 's/load-module module-suspend-on-idle/#load-module module-suspend-on-idle/' /etc/pulse/default.pa
 pulseaudio -k
 ```
 
 This change can be undone using these commands:
 
-```
+```bash
 sudo sed -i 's/#load-module module-suspend-on-idle/load-module module-suspend-on-idle/' /etc/pulse/default.pa
 pulseaudio -k
 ```

--- a/content/serval-dac.md
+++ b/content/serval-dac.md
@@ -19,13 +19,38 @@ section: hardware-troubleshooting
 tableOfContents: true
 ---
 
-On some versions of the Serval WS (including the `serw11`), you may notice a "clicking" sound when the machine powers on and when you begin playing audio. This sound is the DAC (Digital-to-Analog Converter) powering on, and is not an indication that anything is wrong with the hardware.
+On some versions of the Serval WS (including the `serw10` and `serw11`), you may notice a "clicking" sound when the machine powers on and when you begin playing audio. This sound is the DAC (Digital-to-Analog Converter) powering on, and is not an indication that anything is wrong with the hardware.
 
 You can't stop the DAC from clicking when the machine powers on, but you _can_ stop it from clicking every time you begin playing audio. To do this, you'll need to configure the DAC not to power itself off when it's idle. (This way, the DAC will already be powered on when you begin playing audio, and will not need to click.)
 
-These two commands will make the necessary configuration change and restart PulseAudio so it goes into effect immediately:
+## PipeWire with WirePlumber
+
+To adjust the configuration on systems running PipeWire with WirePlumber (including Pop!_OS 22.04 and above), run the following commands to disable the suspend feature (by setting the timeout to 0) and restart PipeWire so it goes into effect immediately:
+
+```bash
+sudo sed -i 's/--\["session.suspend-timeout-seconds"\] = 5/\["session.suspend-timeout-seconds"\] = 0/' /usr/share/wireplumber/main.lua.d/50-alsa-config.lua
+systemctl restart --user pipewire.service
+```
+
+To change the configuration back to the default, run the following commands:
+
+```bash
+sudo sed -i 's/\["session.suspend-timeout-seconds"\] = 0/--\["session.suspend-timeout-seconds"\] = 5/' /usr/share/wireplumber/main.lua.d/50-alsa-config.lua
+systemctl restart --user pipewire.service
+```
+
+## PulseAudio
+
+For older versions of Pop!_OS or distributions still using PulseAudio without PipeWire, the behavior can be adjusted through PulseAudio configuration. These two commands will make the necessary configuration change and restart PulseAudio so it goes into effect immediately:
 
 ```bash
 sudo sed -i 's/load-module module-suspend-on-idle/#load-module module-suspend-on-idle/' /etc/pulse/default.pa
+pulseaudio -k
+```
+
+To change the configuration back to the default, run the following commands:
+
+```bash
+sudo sed -i 's/#load-module module-suspend-on-idle/load-module module-suspend-on-idle/' /etc/pulse/default.pa
 pulseaudio -k
 ```


### PR DESCRIPTION
Closes #1044.

Adds the new instructions for PipeWire, but keeps the old ones for PulseAudio around for reference.

The new PipeWire instructions have been confirmed by several users in Mattermost, and I've also tested it myself on my serw10.