### PR TITLE
minor: document W11 for i9/AMD R3-5k

### DIFF
--- a/content/windows.md
+++ b/content/windows.md
@@ -70,7 +70,7 @@ System76 encourages users to take ownership of their machines and install whatev
 | thelio-mega-r1    | Yes                | Yes*                |
 | thelio-massive-b1 | Yes                | Yes*                |
 
-> **NOTE:** For desktop computers you will want to confirm you have an 8th Gen Intel Core Processor or 2000 Ryzen AMD Processor, and that you have TPM enabled in the UEFI settings.
+*\*For desktop computers you will want to confirm you have an 8th/9th Gen Intel Core Processor or an AMD Ryzen 2000-5XXX Processor, and that you have TPM enabled in the [UEFI settings](https://support.system76.com/articles/windows#using-the-uefi-firmware).*
 
 ### Scope of Support
 


### PR DESCRIPTION
>add confirmation that Intel i9 and AMD 3XXX-5XXX support Windows 11 installs on Thelio mira/major/mega/massive

I've manually confirmed the ability to install W11 on the Thelio Mira with the following chipsets and DDR4 memory running Sys76 non-open firmware:
- AMD Ryzen 7 5800X (ASUS X570-E)
- AMD Ryzen 9 5950X (ASUS X570-E, see `neofetch` below)
- Intel i9-12900K (ASUS Z590-A)

![image](https://user-images.githubusercontent.com/10716475/189484957-822b775e-d843-40eb-943f-48ab76231b31.png)

