### PR TITLE
Update for Plugable UD-ULTC4K

### DIFF
--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -96,6 +96,7 @@ Community members have reported that the following docks work with our products:
 - [Lenovo ThinkPad USB 3.0 Pro Dock](https://support.lenovo.com/us/en/solutions/acc100184-thinkpad-usb-30-pro-dock-overview-and-service-parts) [[community-tested](https://github.com/system76/docs/pull/523) on an Intel system]
   - Ethernet and DVI ports not tested.
 - [Plugable UD-ULTC4K USB-C Triple 4K Display Dock](https://plugable.com/products/ud-ultc4k) [[community-tested](https://github.com/system76/docs/pull/790) on an NVIDIA system] <sup>2,3</sup>
+   - Does not natively support multiple monitors when paired with Lemur. Works fine for one monitor. [[community-tested](my-link) on an Intel system]
 - [Plugable UD-ULTCDL USB-C Triple Display Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
 
 <sup>1</sup> Does not need the DisplayLink Driver installed to work.  

--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -96,7 +96,7 @@ Community members have reported that the following docks work with our products:
 - [Lenovo ThinkPad USB 3.0 Pro Dock](https://support.lenovo.com/us/en/solutions/acc100184-thinkpad-usb-30-pro-dock-overview-and-service-parts) [[community-tested](https://github.com/system76/docs/pull/523) on an Intel system]
   - Ethernet and DVI ports not tested.
 - [Plugable UD-ULTC4K USB-C Triple 4K Display Dock](https://plugable.com/products/ud-ultc4k) [[community-tested](https://github.com/system76/docs/pull/790) on an NVIDIA system] <sup>2,3</sup>
-   - Does not natively support multiple monitors when paired with Lemur. Works fine for one monitor. [[community-tested](my-link) on an Intel system]
+  - Does not natively support multiple monitors when paired with Lemur. Works fine for one monitor. [[community-tested](my-link) on an Intel system]
 - [Plugable UD-ULTCDL USB-C Triple Display Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
 
 <sup>1</sup> Does not need the DisplayLink Driver installed to work.  

--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -96,7 +96,7 @@ Community members have reported that the following docks work with our products:
 - [Lenovo ThinkPad USB 3.0 Pro Dock](https://support.lenovo.com/us/en/solutions/acc100184-thinkpad-usb-30-pro-dock-overview-and-service-parts) [[community-tested](https://github.com/system76/docs/pull/523) on an Intel system]
   - Ethernet and DVI ports not tested.
 - [Plugable UD-ULTC4K USB-C Triple 4K Display Dock](https://plugable.com/products/ud-ultc4k) [[community-tested](https://github.com/system76/docs/pull/790) on an NVIDIA system] <sup>2,3</sup>
-  - Does not natively support multiple monitors when paired with Lemur. Works fine for one monitor. [[community-tested](my-link) on an Intel system]
+  - Does not natively support multiple monitors with Lemur. Works with one monitor ([community-tested](https://github.com/system76/docs/pull/1064) on an Intel system).
 - [Plugable UD-ULTCDL USB-C Triple Display Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
 
 <sup>1</sup> Does not need the DisplayLink Driver installed to work.  

--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -96,7 +96,7 @@ Community members have reported that the following docks work with our products:
 - [Lenovo ThinkPad USB 3.0 Pro Dock](https://support.lenovo.com/us/en/solutions/acc100184-thinkpad-usb-30-pro-dock-overview-and-service-parts) [[community-tested](https://github.com/system76/docs/pull/523) on an Intel system]
   - Ethernet and DVI ports not tested.
 - [Plugable UD-ULTC4K USB-C Triple 4K Display Dock](https://plugable.com/products/ud-ultc4k) [[community-tested](https://github.com/system76/docs/pull/790) on an NVIDIA system] <sup>2,3</sup>
-  - Does not natively support multiple monitors with a Lemur Pro (lemp11). Works with one monitor ([community-tested](https://github.com/system76/docs/pull/1064) on an Intel system).
+  - Does not natively support multiple monitors with a Lemur Pro (lemp11). Works with one monitor [[community-tested](https://github.com/system76/docs/pull/1064) on an Intel system].
 - [Plugable UD-ULTCDL USB-C Triple Display Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
 
 <sup>1</sup> Does not need the DisplayLink Driver installed to work.  

--- a/content/docking-station.md
+++ b/content/docking-station.md
@@ -96,7 +96,7 @@ Community members have reported that the following docks work with our products:
 - [Lenovo ThinkPad USB 3.0 Pro Dock](https://support.lenovo.com/us/en/solutions/acc100184-thinkpad-usb-30-pro-dock-overview-and-service-parts) [[community-tested](https://github.com/system76/docs/pull/523) on an Intel system]
   - Ethernet and DVI ports not tested.
 - [Plugable UD-ULTC4K USB-C Triple 4K Display Dock](https://plugable.com/products/ud-ultc4k) [[community-tested](https://github.com/system76/docs/pull/790) on an NVIDIA system] <sup>2,3</sup>
-  - Does not natively support multiple monitors with Lemur. Works with one monitor ([community-tested](https://github.com/system76/docs/pull/1064) on an Intel system).
+  - Does not natively support multiple monitors with a Lemur Pro (lemp11). Works with one monitor ([community-tested](https://github.com/system76/docs/pull/1064) on an Intel system).
 - [Plugable UD-ULTCDL USB-C Triple Display Dock](https://plugable.com/products/ud-ultcdl/) [[community-tested](https://github.com/system76/docs/pull/518) on an NVIDIA system]
 
 <sup>1</sup> Does not need the DisplayLink Driver installed to work.  


### PR DESCRIPTION
It does not natively support multiple monitors with the Lemur. I tested this myself and when it didn't work, I confirmed this with Pluggable's  support.

Apologies for not linking to the PR number, but I don't know what the number will be before the PR is made.