### PR TITLE
Add NixOS configuration

### DIFF
--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -245,7 +245,7 @@ sudo dnf install system76-oled
 
 ## NixOS
 
-For hardware support this line needs to be added to you `/etc/nixos/configuration.nix` file then rebuild the OS:
+For hardware support, this line needs to be added to your `/etc/nixos/configuration.nix` file then rebuild the OS:
 
 ```bash
 # System76

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -242,3 +242,16 @@ This command will be used to install the <u>System76 OLED</u> which is used for 
 ```bash
 sudo dnf install system76-oled
 ```
+
+## NixOS
+
+For hardware support this line needs to be added to you `/etc/nixos/configuration.nix` file then rebuild the OS:
+
+```bash
+# System76
+hardware.system76.enableAll = true;
+```
+
+```bash
+sudo nixos-rebuild switch
+```


### PR DESCRIPTION
This adds the steps needed for System76 hardware support in NixOS. This does the following:

- Adds system76-power
- Adds system76-firmware
- Adds system76 kernel modules

Documentation:

https://nixos.org/manual/nixos/stable/options.html#opt-hardware.system76.enableAll