### PR TITLE
Docker CUDA updates

### DIFF
--- a/content/cuda.md
+++ b/content/cuda.md
@@ -128,7 +128,7 @@ The container ID can be referenced to copy files into and out of the container:
 
 ```bash
 system76@pop-os:~$ git clone https://github.com/NVIDIA/cuda-samples.git
-system76@pop-os:~$ docker cp Projects/cuda-samples/5397e7ea7f57:/home
+system76@pop-os:~$ docker cp Projects/cuda-samples/ 5397e7ea7f57:/home
 ```
 
 Now, from within the container, an example project can be built:

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -16,7 +16,7 @@ tableOfContents: true
 
 ## Pop!\_OS 22.04 LTS
 
-If you are looking to install other versions of the CUDA libraries other than the version included with the Nvidia driver, we suggest using the `nvidia-container-toolkit` to allow alternate versions of the CUDA libraries to be installed. This should give you native speed that was tested to work by Nvidia as they package the libraries in a docker image. You can see the different iamages that are published here: https://hub.docker.com/r/nvidia/cuda/
+If you are looking to install other versions of the CUDA libraries other than the version included with the Nvidia driver, we suggest using the `nvidia-container-toolkit` to allow alternate versions of the CUDA libraries to be installed. This should give you native speed that was tested to work by Nvidia as they package the libraries in a docker image. You can see the different iamages that are published here: <https://hub.docker.com/r/nvidia/cuda/>
 
 This example installs a development enviroment with CUDA version 12.1.
 

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -134,7 +134,7 @@ system76@pop-os:~$ docker cp Projects/cuda-samples/5397e7ea7f57:/home
 Now, from within the container, an example project can be built:
 
 ```bash
-root@5397e7ea7f57# cd home/cuda-samples/Samples/0_Introductions/c++11_cuda
+root@5397e7ea7f57# cd home/cuda-samples/Samples/0_Introduction/c++11_cuda
 root@5397e7ea7f57:/home/cuda-samples/Samples/0_Introduction/c++11_cuda# make
 ```
 

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -133,7 +133,6 @@ Makefile           README.md   c++11_cuda.cu  c++11_cuda_vs2017.sln      c++11_c
 NsightEclipse.xml  c++11_cuda  c++11_cuda.o   c++11_cuda_vs2017.vcxproj  c++11_cuda_vs2019.vcxproj  c++11_cuda_vs2022.vcxproj  warandpeace.txt
 ```
 
-
 ## Pop!\_OS 20.04 LTS
 
 ### Install the Latest NVIDIA CUDA Toolkit

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -16,11 +16,23 @@ tableOfContents: true
 
 ## Pop!\_OS 22.04 LTS
 
+Basic CUDA runtime functionality is installed automatically with the NVIDIA driver (in the `libnvidia-compute-*` and `nvidia-compute-utils-*` packages). The maximum CUDA version supported by the libraries included with the driver can be seen using the `nvidia-smi` command.
+
+Additional tools for using and developing with CUDA can be installed with the `nvidia-cuda-toolkit` package:
+
+```
+sudo apt install nvidia-cuda-toolkit
+```
+
+The `nvidia-cuda-toolkit` package is [maintained by Ubuntu](https://packages.ubuntu.com/jammy/amd64/nvidia-cuda-toolkit), and may contain an older version of CUDA than what the driver supports.
+
+### Other Versions of CUDA
+
 The `nvidia-container-toolkit` package uses Docker containers to allow alternate versions of the CUDA libraries to be installed alongside the one included with the NVIDIA driver. You can see the different Docker images that are published by NVIDIA here: <https://hub.docker.com/r/nvidia/cuda/>
 
 This example installs a development enviroment with CUDA version 12.1.
 
-## Install Software
+#### Install Software
 
 ```bash
 sudo apt update
@@ -41,22 +53,22 @@ The last step is to add a kernel parameter:
 sudo kernelstub --add-options "systemd.unified_cgroup_hierarchy=0"
 ```
 
-## Configure the Docker daemon for the NVIDIA Containter Runtime
+...and reboot.
+
+#### Configure the Docker daemon for the NVIDIA Containter Runtime
 
 ```bash
 sudo nvidia-ctk runtime configure --runtime=docker
 sudo systemctl restart docker
 ```
 
-...and reboot. Then you're ready for liftoff!
-
-## Test Configuration
+#### Test Configuration
 
 ```bash
 docker run --rm --runtime=nvidia --gpus all nvidia/cuda:12.1.0-devel-ubuntu22.04 nvidia-smi
 ```
 
-We should see this output:
+The output displays the CUDA version supported by the container:
 
 ```
 Thu Mar 23 14:43:51 2023       
@@ -80,13 +92,13 @@ Thu Mar 23 14:43:51 2023
 +-----------------------------------------------------------------------------+
 ```
 
-## Run the Container
+#### Run the Container
 
 ```bash
 docker run -it --rm --runtime=nvidia --gpus all nvidia/cuda:12.1.0-devel-ubuntu22.04 bash
 ```
 
-This allows us to run more than one command:
+This presents a shell where commands can be run with CUDA support:
 
 ```bash
 nvcc --version
@@ -100,7 +112,7 @@ Cuda compilation tools, release 12.1, V12.1.66
 Build cuda_12.1.r12.1/compiler.32415258_0
 ```
 
-This will also have the Container running and we can check this by running this command in another terminal or tab:
+The container can be viewed and managed using Docker in another terminal or tab:
 
 ```bash
 sudo docker ps
@@ -111,18 +123,18 @@ CONTAINER ID   IMAGE                                 COMMAND   CREATED         S
 5397e7ea7f57   nvidia/cuda:12.1.0-devel-ubuntu22.04   "/opt/nvidia/nvidia_…"   2 minutes ago   Up 2 minutes             boring_tesla
 ```
 
-From this Container ID we can copy files into the Container to run:
+The container ID can be referenced to copy files into and out of the container:
 
 ```bash
 git clone https://github.com/NVIDIA/cuda-samples.git
 docker cp Projects/cuda-samples/5397e7ea7f57:/home
 ```
 
-Now in the other terminal window or tab go into the Container and build an example:
+Now, from within the container, an example project can be built:
 
 ```bash
-cd home/cuda-samples/Samples/0_Introductions/c++11_cuda
-make
+root@5397e7ea7f57# cd home/cuda-samples/Samples/0_Introductions/c++11_cuda
+root@5397e7ea7f57:/home/cuda-samples/Samples/0_Introduction/c++11_cuda# make
 ```
 
 You should see the binary built:

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -86,7 +86,7 @@ Thu Mar 23 14:43:51 2023
 docker run -it --rm --runtime=nvidia --gpus all nvidia/cuda:12.1.0-devel-ubuntu22.04 bash
 ```
 
-This allows us to run more then one command:
+This allows us to run more than one command:
 
 ```bash
 nvcc --version

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -34,16 +34,17 @@ This example installs a development enviroment with CUDA version 12.1.
 
 #### Install Software
 
+After making sure the system is up-to-date, install the NVIDIA container toolkit. In this example, Docker will also be installed using the `docker.io` package.
+
 ```bash
 sudo apt update
-sudo apt upgrade
-sudo apt install nvidia-container-toolkit
+sudo apt full-upgrade
+sudo apt install nvidia-container-toolkit docker.io
 ```
 
 The user account working with the Container Toolkit must be added to the `docker` group if that hasn't been done already:
 
 ```bash
-sudo docker.io
 sudo usermod -aG docker $USER
 ```
 
@@ -57,12 +58,16 @@ sudo kernelstub --add-options "systemd.unified_cgroup_hierarchy=0"
 
 #### Configure the Docker daemon for the NVIDIA Containter Runtime
 
+Use the NVIDIA Container Toolkit CLI to configure Docker to use the NVIDIA libraries, then restart Docker:
+
 ```bash
 sudo nvidia-ctk runtime configure --runtime=docker
 sudo systemctl restart docker
 ```
 
 #### Test Configuration
+
+Run this command to check the Docker configuration for CUDA:
 
 ```bash
 docker run --rm --runtime=nvidia --gpus all nvidia/cuda:12.1.0-devel-ubuntu22.04 nvidia-smi
@@ -94,17 +99,16 @@ Thu Mar 23 14:43:51 2023
 
 #### Run the Container
 
+Start a shell within the container:
+
 ```bash
 docker run -it --rm --runtime=nvidia --gpus all nvidia/cuda:12.1.0-devel-ubuntu22.04 bash
 ```
 
-This presents a shell where commands can be run with CUDA support:
+Commands can then be run with CUDA support:
 
-```bash
-nvcc --version
-```
-
-```
+```shell
+root@5397e7ea7f57:/# nvcc --version
 nvcc: NVIDIA (R) Cuda compiler driver
 Copyright (c) 2005-2023 NVIDIA Corporation
 Built on Tue_Feb__7_19:32:13_PST_2023
@@ -112,13 +116,10 @@ Cuda compilation tools, release 12.1, V12.1.66
 Build cuda_12.1.r12.1/compiler.32415258_0
 ```
 
-The container can be viewed and managed using Docker in another terminal or tab:
+The container can be viewed and managed using `docker ps` in another terminal or tab:
 
 ```bash
-sudo docker ps
-```
-
-```
+system76@pop-os:~$ docker ps
 CONTAINER ID   IMAGE                                 COMMAND   CREATED         STATUS         PORTS     NAMES
 5397e7ea7f57   nvidia/cuda:12.1.0-devel-ubuntu22.04   "/opt/nvidia/nvidia_…"   2 minutes ago   Up 2 minutes             boring_tesla
 ```
@@ -126,8 +127,8 @@ CONTAINER ID   IMAGE                                 COMMAND   CREATED         S
 The container ID can be referenced to copy files into and out of the container:
 
 ```bash
-git clone https://github.com/NVIDIA/cuda-samples.git
-docker cp Projects/cuda-samples/5397e7ea7f57:/home
+system76@pop-os:~$ git clone https://github.com/NVIDIA/cuda-samples.git
+system76@pop-os:~$ docker cp Projects/cuda-samples/5397e7ea7f57:/home
 ```
 
 Now, from within the container, an example project can be built:

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -127,8 +127,8 @@ CONTAINER ID   IMAGE                                 COMMAND   CREATED         S
 The container ID can be referenced to copy files into and out of the container:
 
 ```bash
-system76@pop-os:~$ git clone https://github.com/NVIDIA/cuda-samples.git
-system76@pop-os:~$ docker cp Projects/cuda-samples/ 5397e7ea7f57:/home
+git clone https://github.com/NVIDIA/cuda-samples.git Projects/cuda-samples/
+docker cp Projects/cuda-samples/. 5397e7ea7f57:/home/cuda-samples/
 ```
 
 Now, from within the container, an example project can be built:

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -127,36 +127,40 @@ CONTAINER ID   IMAGE                                 COMMAND   CREATED         S
 The container ID can be referenced to copy files into and out of the container:
 
 ```bash
-git clone https://github.com/NVIDIA/cuda-samples.git Projects/cuda-samples/
-docker cp Projects/cuda-samples/. 5397e7ea7f57:/home/cuda-samples/
+system76@pop-os:~$ git clone https://github.com/NVIDIA/cuda-samples.git
+system76@pop-os:~$ docker cp cuda-samples/ 5397e7ea7f57:/root/cuda-samples/
 ```
 
 Now, from within the container, an example project can be built:
 
 ```bash
-root@5397e7ea7f57# cd home/cuda-samples/Samples/0_Introduction/c++11_cuda
-root@5397e7ea7f57:/home/cuda-samples/Samples/0_Introduction/c++11_cuda# make
+root@5397e7ea7f57# cd /root/cuda-samples/Samples/0_Introduction/c++11_cuda/
+root@5397e7ea7f57:~/cuda-samples/Samples/0_Introduction/c++11_cuda# make
 ```
 
-You should see the binary built:
+The binary (`c++11_cuda`) is built:
 
 ```
-root@5397e7ea7f57:/home/cuda-samples/Samples/0_Introduction/c++11_cuda# ls
-Makefile           README.md   c++11_cuda.cu  c++11_cuda_vs2017.sln      c++11_cuda_vs2019.sln      c++11_cuda_vs2022.sln      range.hpp
-NsightEclipse.xml  c++11_cuda  c++11_cuda.o   c++11_cuda_vs2017.vcxproj  c++11_cuda_vs2019.vcxproj  c++11_cuda_vs2022.vcxproj  warandpeace.txt
+root@5397e7ea7f57:~/cuda-samples/Samples/0_Introduction/c++11_cuda# ls -l
+total 6108
+-rw-rw-r-- 1 1000 1000   13679 Mar 24 16:45 Makefile
+-rw-rw-r-- 1 1000 1000    2090 Mar 24 16:45 NsightEclipse.xml
+-rw-rw-r-- 1 1000 1000    3556 Mar 24 16:45 README.md
+-rwxr-xr-x 1 root root 1881448 Mar 24 16:48 c++11_cuda
+...
 ```
 
 ## Pop!\_OS 20.04 LTS
 
 ### Install the Latest NVIDIA CUDA Toolkit
 
-To install the CUDA toolkit, please run this command:
+To install the CUDA toolkit, run this command:
 
 ```bash
 sudo apt install system76-cuda-latest
 ```
 
-To install the cuDNN library, please run this command:
+To install the cuDNN library, run this command:
 
 ```bash
 sudo apt install system76-cudnn-11.2

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -16,7 +16,9 @@ tableOfContents: true
 
 ## Pop!\_OS 22.04 LTS
 
-It is recommended to use NVIDIA Container Toolkit as newer versions of CUDA are no longer packaged on their own.
+If you are looking to install other versions of the CUDA libraries other than the version included with the Nvidia driver, we suggest using the `nvidia-container-toolkit` to allow alternate versions of the CUDA libraries to be installed. This should give you native speed that was tested to work by Nvidia as they package the libraries in a docker image. You can see the different iamages that are published here: https://hub.docker.com/r/nvidia/cuda/
+
+This example installs a development enviroment with CUDA version 12.1.
 
 ## Install Software
 
@@ -29,6 +31,7 @@ sudo apt install nvidia-container-toolkit
 The user account working with the Container Toolkit must be added to the `docker` group if that hasn't been done already:
 
 ```bash
+sudo docker.io
 sudo usermod -aG docker $USER
 ```
 
@@ -50,7 +53,7 @@ sudo systemctl restart docker
 ## Test Configuration
 
 ```bash
-sudo docker run --rm --runtime=nvidia --gpus all nvidia/cuda:12.1.0-devel-ubuntu22.04 nvidia-smi
+docker run --rm --runtime=nvidia --gpus all nvidia/cuda:12.1.0-devel-ubuntu22.04 nvidia-smi
 ```
 
 We should see this output:
@@ -80,7 +83,7 @@ Thu Mar 23 14:43:51 2023
 ## Run the Container
 
 ```bash
-sudo docker run -it --rm --runtime=nvidia --gpus all nvidia/cuda:12.1.0-devel-ubuntu22.04 bash
+docker run -it --rm --runtime=nvidia --gpus all nvidia/cuda:12.1.0-devel-ubuntu22.04 bash
 ```
 
 This allows us to run more then one command:
@@ -112,7 +115,7 @@ From this Container ID we can copy files into the Container to run:
 
 ```bash
 git clone https://github.com/NVIDIA/cuda-samples.git
-sudo docker cp Projects/cuda-samples/5397e7ea7f57:/home
+docker cp Projects/cuda-samples/5397e7ea7f57:/home
 ```
 
 Now in the other terminal window or tab go into the Container and build an example:

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -16,7 +16,7 @@ tableOfContents: true
 
 ## Pop!\_OS 22.04 LTS
 
-If you are looking to install other versions of the CUDA libraries other than the version included with the Nvidia driver, we suggest using the `nvidia-container-toolkit` to allow alternate versions of the CUDA libraries to be installed. This should give you native speed that was tested to work by Nvidia as they package the libraries in a docker image. You can see the different iamages that are published here: <https://hub.docker.com/r/nvidia/cuda/>
+The `nvidia-container-toolkit` package uses Docker containers to allow alternate versions of the CUDA libraries to be installed alongside the one included with the NVIDIA driver. You can see the different Docker images that are published by NVIDIA here: <https://hub.docker.com/r/nvidia/cuda/>
 
 This example installs a development enviroment with CUDA version 12.1.
 

--- a/content/cuda.md
+++ b/content/cuda.md
@@ -56,7 +56,7 @@ sudo kernelstub --add-options "systemd.unified_cgroup_hierarchy=0"
 
 ...and reboot.
 
-#### Configure the Docker daemon for the NVIDIA Containter Runtime
+#### Configure the Docker daemon for the NVIDIA Container Runtime
 
 Use the NVIDIA Container Toolkit CLI to configure Docker to use the NVIDIA libraries, then restart Docker:
 


### PR DESCRIPTION
Recent request from customers on how to get specific versions of CUDA led to adding steps and commands that will get CUDA 12.1 installed as docker image files. 

Spot tested the instructions and both reported CUDA version matches 12.1 but `nvcc` version is present and matches expected version. Building example CUDA projects works