### PR TITLE
[FIX] kernelstub: wrong command for adding kernel options

### DIFF
--- a/content/kernelstub.md
+++ b/content/kernelstub.md
@@ -39,7 +39,7 @@ The benefit of `kernelstub` is the ease with which kernel options and boot param
 For example, the command below adds both "quiet" and "splash" to the kernel options:
 
 ```bash
-sudo kernelstub -o "quiet splash"
+sudo kernelstub -a "quiet splash"
 ```
 
 A full set of available options are listed on the Github page. They can also be printed out in the Terminal by passing:


### PR DESCRIPTION
The `-o` option actually replaces the whole boot options' list passed to the kernel instead of adding to the configuration (if they aren't present already), which is done using `-a` (or the lengthier `--add-options`).