### PR TITLE
Add missing `addw3`, `gaze18`, `oryp11` models

### DIFF
--- a/content/graphics-switch-pop.md
+++ b/content/graphics-switch-pop.md
@@ -28,12 +28,12 @@ tableOfContents: true
 Many modern laptops with NVIDIA graphics cards have switchable graphics, which allows users to switch their primary GPU between the CPU's integrated graphics processor and the dedicated NVIDIA graphics card.
 The following System76 laptops have these switchable graphics capabilities:
 
-- Adder WS (addw1, addw2)
+- Adder WS (addw1, addw2, addw3)
 - Bonobo WS (bonw15)
 - Galago Pro (galp5 - NVIDIA models only)
 - Gazelle (gaze14, gaze15, gaze16, gaze17, gaze18)
 - Kudu (kudu6)
-- Oryx Pro (oryp4, oryp4-b, oryp5, oryp6, oryp7, oryp8, oryp9, oryp10)
+- Oryx Pro (oryp4, oryp4-b, oryp5, oryp6, oryp7, oryp8, oryp9, oryp10, oryp11)
 - Serval WS (serw13)
 
 Pop!\_OS includes utilities for switching between these modes, which you can learn more about below.

--- a/content/graphics-switch-pop.md
+++ b/content/graphics-switch-pop.md
@@ -29,10 +29,12 @@ Many modern laptops with NVIDIA graphics cards have switchable graphics, which a
 The following System76 laptops have these switchable graphics capabilities:
 
 - Adder WS (addw1, addw2)
+- Bonobo WS (bonw15)
 - Galago Pro (galp5 - NVIDIA models only)
-- Gazelle (gaze14, gaze15, gaze16, gaze17)
+- Gazelle (gaze14, gaze15, gaze16, gaze17, gaze18)
 - Kudu (kudu6)
 - Oryx Pro (oryp4, oryp4-b, oryp5, oryp6, oryp7, oryp8, oryp9, oryp10)
+- Serval WS (serw13)
 
 Pop!\_OS includes utilities for switching between these modes, which you can learn more about below.
 

--- a/content/graphics-switch-ubuntu.md
+++ b/content/graphics-switch-ubuntu.md
@@ -27,7 +27,7 @@ tableOfContents: true
 
 Many modern laptops with NVIDIA graphics cards have switchable graphics, which allows users to switch their primary GPU between the CPU's integrated graphics processor and the dedicated NVIDIA graphics card. The following System76 laptops have these switchable graphics capabilities:
 
-- Adder WS (addw1, addw2)
+- Adder WS (addw1, addw2, addw3)
 - Bonobo WS (bonw15)
 - Galago Pro (galp5 - NVIDIA models only)
 - Gazelle (gaze14, gaze15, gaze16, gaze17, gaze18)

--- a/content/graphics-switch-ubuntu.md
+++ b/content/graphics-switch-ubuntu.md
@@ -32,7 +32,7 @@ Many modern laptops with NVIDIA graphics cards have switchable graphics, which a
 - Galago Pro (galp5 - NVIDIA models only)
 - Gazelle (gaze14, gaze15, gaze16, gaze17, gaze18)
 - Kudu (kudu6)
-- Oryx Pro (oryp4, oryp4-b, oryp5, oryp6, oryp7, oryp8, oryp9, oryp10)
+- Oryx Pro (oryp4, oryp4-b, oryp5, oryp6, oryp7, oryp8, oryp9, oryp10, oryp11)
 - Serval WS (serw13)
 
 ## Graphics modes

--- a/content/graphics-switch-ubuntu.md
+++ b/content/graphics-switch-ubuntu.md
@@ -28,10 +28,12 @@ tableOfContents: true
 Many modern laptops with NVIDIA graphics cards have switchable graphics, which allows users to switch their primary GPU between the CPU's integrated graphics processor and the dedicated NVIDIA graphics card. The following System76 laptops have these switchable graphics capabilities:
 
 - Adder WS (addw1, addw2)
+- Bonobo WS (bonw15)
 - Galago Pro (galp5 - NVIDIA models only)
-- Gazelle (gaze14, gaze15, gaze16, gaze17)
+- Gazelle (gaze14, gaze15, gaze16, gaze17, gaze18)
 - Kudu (kudu6)
 - Oryx Pro (oryp4, oryp4-b, oryp5, oryp6, oryp7, oryp8, oryp9, oryp10)
+- Serval WS (serw13)
 
 ## Graphics modes
 


### PR DESCRIPTION
This adds new models to the list with switchable graphics. I wonder if we should just put the models that we started offering switchable graphics since every system in the 13th Gen Intel has a dGPU so it has switchable graphics. Then we would not have to update this page as often. 