### PR TITLE
Add note about new 90% default start threshold

### DIFF
--- a/content/laptop-battery-thresholds.md
+++ b/content/laptop-battery-thresholds.md
@@ -16,11 +16,13 @@ tableOfContents: true
 
 Charging thresholds allow your System76 laptop to avoid charging the battery until it has dropped below a lower bound (the start threshold), and to stop charging when it reaches an upper bound (the end threshold). This is useful when your laptop is plugged into an AC power adapter for extended periods of time, as it prevents unnecessary micro-charging that would reduce battery longevity.
 
+The default charging profile for System76 laptops with Open Firmware has a start threshold of 90 and a stop threshold of 100. This increases battery longevity while keeping the battery very close to a full charge.
+
 To determine if your laptop has Open Firmware or proprietary firmware, see [this article](/articles/open-firmware-systems). (If a system has Open Firmware, then it must also have Open EC to work with charging thresholds.) See [Charging Thresholds](#configuring-charging-thresholds-open-firmware) for Open Firmware systems or [FlexiCharger](#configuring-flexicharger-proprietary-firmware) for proprietary firmware systems.
 
 ## Configuring Charging Thresholds (Open Firmware)
 
-**Note:** This feature is not currently finished. Currently, the thresholds are reset when the EC is reset (which happens when the system is shut down and the power is unplugged.) Once the feature is complete, the thresholds will be persistent and a GUI will be available to set them. To work around this limitation in the short term, you can [use systemd to set thresholds at boot](#at-boot).
+**Note:** This feature is not currently finished. Currently, the thresholds are reset when the EC is reset (which happens when the system is shut down and the power is unplugged). Once the feature is complete, the thresholds will be persistent and a GUI will be available to set them. To work around this limitation in the short term, you can [use systemd to set thresholds at boot](#at-boot).
 
 ### Using the terminal
 


### PR DESCRIPTION
I'm not sure if the note needs to be more obvious, but this at least gets the info into this article.

Also corrected two instances of periods inside of parentheses. They should be outside.

Side note: further down, the "Proprietary firmware" section doesn't apply to the Pangolin. I might need to file an issue about that one.