### PR TITLE
Use recursive binding before chroot

### DIFF
--- a/content/pop-recovery.md
+++ b/content/pop-recovery.md
@@ -116,7 +116,7 @@ The EFI partition is the next partition to be mounted. To help identify it, this
 | ```sudo mount /dev/sda1 /mnt/boot/efi```    | ```sudo mount /dev/nvme0n1p1 /mnt/boot/efi```  |
 
 ```bash
-for i in /dev /dev/pts /proc /sys /run; do sudo mount -B $i /mnt$i; done
+for i in /dev /dev/pts /proc /sys /run; do sudo mount -R $i /mnt$i; done
 sudo chroot /mnt
 ```
 


### PR DESCRIPTION
By using -R instead of -B, we ensure that the nested mount of /sys/firmware/efi/efivars/ becomes mounted in our target filesystem, which allows us to do various boot repairs with an EFI system.