### PR TITLE
Add pang13 and pang14 to missing spots in articles

### DIFF
--- a/content/boot-menu.md
+++ b/content/boot-menu.md
@@ -20,7 +20,7 @@ The BIOS or boot menu can be accessed by holding specific keys down during boot.
 
 | Model                                                       | BIOS key | Boot Menu key                     |
 |:-----------------------------------------------------------:|:--------:|:---------------------------------:|
-| Laptops:<br/>All Open Firmware models<br/>Pangolin (pang12) | ESC      | ESC:<br/>Select `One Time Boot` (Open Firmware)<br/>or `Save & Exit` → `Boot Override`. |
+| Laptops:<br/>All Open Firmware models<br/>Pangolin (pang12 and above) | ESC      | ESC:<br/>Select `One Time Boot` (Open Firmware)<br/>or `Save & Exit` → `Boot Override`. |
 | Laptops:<br/>Most proprietary firmware models               | F2       | F7                                |
 | Older laptops                                               | Depends on the system | F1                   |
 | Thelio desktops                                             | Del      | F8/F11/F12                         |

--- a/content/guides.md
+++ b/content/guides.md
@@ -59,6 +59,7 @@ To see ports, keyboard layouts, function keys, and product quickstart guides, fi
 | Pangolin [(pang11)](https://tech-docs.system76.com/models/pang11/README.html) |
 | Pangolin [(pang12)](https://tech-docs.system76.com/models/pang12/README.html) |
 | Pangolin [(pang13)](https://tech-docs.system76.com/models/pang13/README.html) |
+| Pangolin [(pang14)](https://tech-docs.system76.com/models/pang14/README.html) |
 | Serval WS [(serw12)](https://tech-docs.system76.com/models/serw12/README.html) |
 | Serval WS [(serw13)](https://tech-docs.system76.com/models/serw13/README.html) |
 

--- a/content/laptop-battery-thresholds.md
+++ b/content/laptop-battery-thresholds.md
@@ -98,4 +98,4 @@ To adjust the thresholds, reboot the computer and enter the UEFI setup utility b
 
 Once configured, save and exit the setup utility. The thresholds can be disabled at any time by setting FlexiCharger back to Disabled.
 
-**Note:** The pang12 and pang13 do not support FlexiCharging.
+**Note:** The pang12, pang13 and pang14 do not support FlexiCharging.

--- a/content/touchpad.md
+++ b/content/touchpad.md
@@ -18,7 +18,7 @@ section: hardware
 tableOfContents: true
 ---
 
-On most System76 laptops, press <kbd>Fn</kbd>+<kbd>F1</kbd> to turn your laptop touchpad on/off. On the Pangolin (pang12), press <kbd>Fn</kbd>+<kbd>F6</kbd>.
+On most System76 laptops, press <kbd>Fn</kbd>+<kbd>F1</kbd> to turn your laptop touchpad on/off. On some Pangolin models (pang12, pang13, pang14), press <kbd>Fn</kbd>+<kbd>F6</kbd>.
 
 To configure your touchpad, press the Super key (<kbd><font-awesome-icon :icon="['fab', 'ubuntu']"></font-awesome-icon></kbd>/<kbd><font-awesome-icon :icon="['fab', 'pop-os']"></font-awesome-icon></kbd>), then type <u>Mouse & Touchpad</u> and click on the result.
 

--- a/content/webcam.md
+++ b/content/webcam.md
@@ -19,7 +19,7 @@ tableOfContents: true
 If you can’t see the image from your webcam or you receive a "No device found!" error when you try to use it, ensure that it's not toggled off.
 
 - On most System76 laptops, press <kbd>Fn</kbd>+<kbd>F10</kbd> to toggle the camera on, then restart the application using the webcam (such as <u>Cheese</u>).
-- On some Pangolin models (pang12 and pang13), there is a physical switch on the left side of the computer (while facing the screen). Ensure the switch is switched on, then restart the application using the webcam (such as <u>Cheese</u>).
+- On some Pangolin models (pang12, pang13 and pang14), there is a physical switch on the left side of the computer (while facing the screen). Ensure the switch is switched on, then restart the application using the webcam (such as <u>Cheese</u>).
   - The Pangolin models with a physical webcam switch do not have a webcam toggle key combination.
 
 ![Cheese](/images/webcam/cheese.png)

--- a/content/windows.md
+++ b/content/windows.md
@@ -75,6 +75,8 @@ Installing Windows is undertaken at your own risk. It's possible not all hardwar
 | pang10       | Yes                | Yes                |
 | pang11       | Yes                | Yes                |
 | pang12       | Yes                | Yes                |
+| pang13       | Yes                | Yes                |
+| pang14       | Yes                | Yes                |
 | serw12       | Yes                | Yes                |
 | serw13       | Yes                | Yes                |
 


### PR DESCRIPTION
We may want to redo this a bit with the growing list of Pangolin models that these sections of articles cover. 