### PR TITLE
Add nix-shell file to use nix for testing

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    nativeBuildInputs = with pkgs; [ 
+       nodejs-18_x 
+       nodePackages.npm
+       ];
+  shellHook =
+  ''
+    cd /home/aaronh/Projects/system76/docs
+    npm ci
+    npm start
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -4,10 +4,4 @@
        nodejs-18_x 
        nodePackages.npm
        ];
-  shellHook =
-  ''
-    cd /home/aaronh/Projects/system76/docs
-    npm ci
-    npm start
-  '';
 }


### PR DESCRIPTION
This allows someone to use `nix` to test changes to the docs. This also allows someone to not need to use the NodeJS package or PPA (for a newer version of NodeJS) so less packages/PPAs.