### PR TITLE
Add note about need to disable ppd on NixOS

### DIFF
--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -271,8 +271,7 @@ hardware.system76.enableAll = true;
 sudo nixos-rebuild switch
 ```
 
-If your system has power-profiles-daemon installed (done by default on Gnome installs), you'll need to disable it for system76-power to start. Add this line to your `/etc/nixos/configuration.nix` file then rebuild the OS:
-
+If your system has power-profiles-daemon installed (done by default on GNOME), you'll need to disable it for system76-power to start. Add this line to your `/etc/nixos/configuration.nix` file then rebuild the OS:
 
 ```bash
 services.power-profiles-daemon.enable = false;

--- a/content/system76-software.md
+++ b/content/system76-software.md
@@ -270,3 +270,14 @@ hardware.system76.enableAll = true;
 ```bash
 sudo nixos-rebuild switch
 ```
+
+If your system has power-profiles-daemon installed (done by default on Gnome installs), you'll need to disable it for system76-power to start. Add this line to your `/etc/nixos/configuration.nix` file then rebuild the OS:
+
+
+```bash
+services.power-profiles-daemon.enable = false;
+```
+
+```bash
+sudo nixos-rebuild switch
+```


### PR DESCRIPTION
power-profiles-daemon (enabled by default on Gnome NixOS installs) must be disabled for system76-power to start. This PR includes that info in docs.