### PR TITLE
Add info on docker usage to rocm install instructions

### DIFF
--- a/content/rocm.md
+++ b/content/rocm.md
@@ -88,7 +88,7 @@ system76@pop-os:~$
 
 Instructions from AMD for building and running a docker image with Pytorch and ROCm are [here](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/3rd-party/pytorch-install.html#using-docker-with-pytorch-pre-installed). Note that you will likely have to run the docker commands as sudo (ie. `sudo docker run -it ...`) for typical docker setups.
 
-Also note that Docker Desktop runs in a virtual environment so it's recommended to use the Docker engine instead to avoid permissions issues. One way to install the Docker engine is to install the `docker.io` package:
+Also note that Docker Desktop runs in a virtual environment so it's recommended to use the Docker engine instead to avoid permissions issues. Instructions on installing the Docker engine are [on Docker's website](https://docs.docker.com/engine/install/ubuntu/). Another way to install the Docker engine is to install the `docker.io` package which is maintained by Ubuntu: 
 
 ```sh
 sudo apt install docker.io

--- a/content/rocm.md
+++ b/content/rocm.md
@@ -84,6 +84,19 @@ Agent 2
 system76@pop-os:~$ 
 ```
 
+### Docker Compatibility
+
+Instructions from AMD for building and running a docker image with Pytorch and ROCM are [here](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/3rd-party/pytorch-install.html#using-docker-with-pytorch-pre-installed). Note that Docker Desktop runs in a virtual environment so it's recommended to use the docker.io package instead to avoid permissions issues. To install docker.io:
+
+```sh
+sudo apt install docker.io
+sudo usermod -aG docker $USER
+```
+
+Also note that you may need to run docker commands using sudo (ie. `sudo docker run -it ....`). 
+
 ### Blender Compatibility
 
 The default Blender `.deb` package in Pop!\_OS 22.04, which is provided by Ubuntu, does not support HIP workloads. The Blender flatpak package may be unable to properly detect the GPU(s) due to sandboxing restrictions. Therefore, for GPU rendering with HIP in Blender, it's recommended to [download Blender directly from blender.org](https://www.blender.org/). (After extracting the `.tar.xz` file, simply double-click the `blender` executable to run the program.)
+
+

--- a/content/rocm.md
+++ b/content/rocm.md
@@ -84,19 +84,17 @@ Agent 2
 system76@pop-os:~$ 
 ```
 
-### Docker Compatibility
+### Using Docker
 
-Instructions from AMD for building and running a docker image with Pytorch and ROCM are [here](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/3rd-party/pytorch-install.html#using-docker-with-pytorch-pre-installed). Note that Docker Desktop runs in a virtual environment so it's recommended to use the docker.io package instead to avoid permissions issues. To install docker.io:
+Instructions from AMD for building and running a docker image with Pytorch and ROCm are [here](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/3rd-party/pytorch-install.html#using-docker-with-pytorch-pre-installed). Note that you will likely have to run the docker commands as sudo (ie. `sudo docker run -it ...`) for typical docker setups.
+
+Also note that Docker Desktop runs in a virtual environment so it's recommended to use the Docker engine instead to avoid permissions issues. One way to install the Docker engine is to install the `docker.io` package:
 
 ```sh
 sudo apt install docker.io
 sudo usermod -aG docker $USER
 ```
 
-Also note that you may need to run docker commands using sudo (ie. `sudo docker run -it ....`). 
-
 ### Blender Compatibility
 
 The default Blender `.deb` package in Pop!\_OS 22.04, which is provided by Ubuntu, does not support HIP workloads. The Blender flatpak package may be unable to properly detect the GPU(s) due to sandboxing restrictions. Therefore, for GPU rendering with HIP in Blender, it's recommended to [download Blender directly from blender.org](https://www.blender.org/). (After extracting the `.tar.xz` file, simply double-click the `blender` executable to run the program.)
-
-

--- a/content/rocm.md
+++ b/content/rocm.md
@@ -86,9 +86,9 @@ system76@pop-os:~$
 
 ### Using Docker
 
-Instructions from AMD for building and running a docker image with Pytorch and ROCm are [here](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/3rd-party/pytorch-install.html#using-docker-with-pytorch-pre-installed). Note that you will likely have to run the docker commands as sudo (ie. `sudo docker run -it ...`) for typical docker setups.
+Instructions from AMD for building and running a Docker image with Pytorch and ROCm are [here](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/3rd-party/pytorch-install.html#using-docker-with-pytorch-pre-installed). Note that you will likely have to run the Docker commands as sudo (i.e. `sudo docker run -it ...`) for typical Docker setups.
 
-Also note that Docker Desktop runs in a virtual environment so it's recommended to use the Docker engine instead to avoid permissions issues. Instructions on installing the Docker engine are [on Docker's website](https://docs.docker.com/engine/install/ubuntu/). Another way to install the Docker engine is to install the `docker.io` package which is maintained by Ubuntu: 
+Also note that Docker Desktop runs in a virtual environment, so it's recommended to use Docker Engine instead to avoid permission issues. Instructions on installing the latest version of Docker Engine are [on Docker's website](https://docs.docker.com/engine/install/ubuntu/). You can alternatively install Docker Engine via the `docker.io` package, which is maintained by Ubuntu (and may not be up-to-date):
 
 ```sh
 sudo apt install docker.io


### PR DESCRIPTION
I ran into some permissions issues using Docker Desktop with ROCM and was able to resolve these issues by using docker.io instead and running docker as sudo. You can refer to the comments [here](https://gist.github.com/guilt/6c901f7ac0a726685b6334798da77c00?permalink_comment_id=5131866#gistcomment-5131866) for more information.

I thought it would be good to add a note here so that others can avoid these issues.