### PR TITLE
Do not keep gh-pages history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,3 +45,4 @@ jobs:
           cname: support.system76.com
           github_token: ${{ secrets.RELEASE_TOKEN }}
           publish_dir: ./dist
+          force_orphan: true


### PR DESCRIPTION
Keeping the history of gh-pages adds a lot of bloat when trying to clone the repository. The force_orphan option added pushes just one commit with no prior history to the gh-pages branch on every change, which should significantly reduce the size of the repository.