### PR TITLE
Update battery thresholds article

### DIFF
--- a/content/laptop-battery-thresholds.md
+++ b/content/laptop-battery-thresholds.md
@@ -22,11 +22,14 @@ The default charging profile for System76 laptops with Open Firmware has a start
 
 To determine if your laptop has Open Firmware or proprietary firmware, see [this article](/articles/open-firmware-systems). (If a system has Open Firmware, then it must also have Open EC to work with charging thresholds.) See [Charging Thresholds](#configuring-charging-thresholds-open-firmware) for Open Firmware systems or [FlexiCharger](#configuring-flexicharger-proprietary-firmware) for proprietary firmware systems.
 
-## Do not support Charging Thresholds or FlexiCharge
+## Charging Thresholds or FlexiCharge support
 
-| Model | Codename |
-|:-----:|:---------:|
-| Pangolin | pang12-pang15 |
+| Model | Codename | Charging Thresholds | FleixCharger |
+|:-----:|:---------:|:---------:|:---------:|
+| Pangolin | pang12 | No | No |
+| Pangolin | pang13 | No | No |
+| Pangolin | pang14 | No | No |
+| Pangolin | pang15 | No | No |
 
 ## Configuring Charging Thresholds (Open Firmware)
 

--- a/content/laptop-battery-thresholds.md
+++ b/content/laptop-battery-thresholds.md
@@ -20,6 +20,12 @@ The default charging profile for System76 laptops with Open Firmware has a start
 
 To determine if your laptop has Open Firmware or proprietary firmware, see [this article](/articles/open-firmware-systems). (If a system has Open Firmware, then it must also have Open EC to work with charging thresholds.) See [Charging Thresholds](#configuring-charging-thresholds-open-firmware) for Open Firmware systems or [FlexiCharger](#configuring-flexicharger-proprietary-firmware) for proprietary firmware systems.
 
+## Do not support Charging Thresholds or FlexiCharge
+
+| Model | Codename |
+|:-----:|:---------:|
+| Pangolin | pang12-pang14 |
+
 ## Configuring Charging Thresholds (Open Firmware)
 
 **Note:** This feature is not currently finished. Currently, the thresholds are reset when the EC is reset (which happens when the system is shut down and the power is unplugged). Once the feature is complete, the thresholds will be persistent and a GUI will be available to set them. To work around this limitation in the short term, you can [use systemd to set thresholds at boot](#at-boot).
@@ -97,5 +103,3 @@ To adjust the thresholds, reboot the computer and enter the UEFI setup utility b
 ![Enabling FlexiCharger](/images/laptop-charging-thresholds/flexicharger.jpg)
 
 Once configured, save and exit the setup utility. The thresholds can be disabled at any time by setting FlexiCharger back to Disabled.
-
-**Note:** The pang12, pang13 and pang14 do not support FlexiCharging.

--- a/content/laptop-battery-thresholds.md
+++ b/content/laptop-battery-thresholds.md
@@ -22,14 +22,14 @@ The default charging profile for System76 laptops with Open Firmware has a start
 
 To determine if your laptop has Open Firmware or proprietary firmware, see [this article](/articles/open-firmware-systems). (If a system has Open Firmware, then it must also have Open EC to work with charging thresholds.) See [Charging Thresholds](#configuring-charging-thresholds-open-firmware) for Open Firmware systems or [FlexiCharger](#configuring-flexicharger-proprietary-firmware) for proprietary firmware systems.
 
-## Charging Thresholds or FlexiCharge support
+## Models that do not support either Charging Thresholds or FlexiCharge
 
-| Model | Codename | Charging Thresholds | FleixCharger |
-|:-----:|:---------:|:---------:|:---------:|
-| Pangolin | pang12 | No | No |
-| Pangolin | pang13 | No | No |
-| Pangolin | pang14 | No | No |
-| Pangolin | pang15 | No | No |
+| Model | Codename |
+|:-----:|:---------:|
+| Pangolin | pang12 |
+| Pangolin | pang13 |
+| Pangolin | pang14 |
+| Pangolin | pang15 |
 
 ## Configuring Charging Thresholds (Open Firmware)
 

--- a/content/laptop-battery-thresholds.md
+++ b/content/laptop-battery-thresholds.md
@@ -5,6 +5,8 @@ description: >
 keywords:
   - Battery
   - Battery Life
+  - Charging Thresholds
+  - FlexiCharge
 
 facebookImage: /_social/article
 twitterImage: /_social/article
@@ -24,7 +26,7 @@ To determine if your laptop has Open Firmware or proprietary firmware, see [this
 
 | Model | Codename |
 |:-----:|:---------:|
-| Pangolin | pang12-pang14 |
+| Pangolin | pang12-pang15 |
 
 ## Configuring Charging Thresholds (Open Firmware)
 


### PR DESCRIPTION
This PR does the following:

- Changes the note to a table about the Pangolin models that do not support either option
- Moves the table to the top about thresholds in general rather than the bottom
- Notes that they do not support Charging Thresholds as well as FlexiCharge
- Adds keywords