### PR TITLE
note on etcher data collection

### DIFF
--- a/content/live-disk.md
+++ b/content/live-disk.md
@@ -122,6 +122,8 @@ Once the flash is complete (should look like the screenshot above), it's time to
 
 Etcher is an open source app for Windows, macOS, and Linux that allows you to burn disk images to USB drives. You can download it at [balena.io/etcher/](https://www.balena.io/etcher/).
 
+> Note: Balena Etcher collects usage statistics by default. You can turn off this data collection in Settings.
+
 Once you have installed Etcher and downloaded the Pop!\_OS.iso image, open up the Etcher application. You should see something like this:
 
 ![Etcher Startup](/images/live-disk-new/etcher01-start.png)


### PR DESCRIPTION
This PR is to add a note about data collection in the recommended Windows imaging tool, balena Etcher.

I was dismayed to find the recommended app Etcher had data collection, and it is on by default. I did not think to check until after I had used it. I think this is important to note for future users. Longer term, a different tool should be recommended because of this.