### PR TITLE
Add meer8, previous models, and meer10 to open firmware list

### DIFF
--- a/content/open-firmware-systems.md
+++ b/content/open-firmware-systems.md
@@ -53,7 +53,9 @@ The source code for our Open EC can be found [here](https://github.com/system76/
 | Gazelle (gaze16 and newer)   | Yes           | Yes     |
 | Lemur Pro (lemp8 and older)  | No            | No      |
 | Lemur Pro (lemp9 and newer)  | Yes           | Yes     |
+| Meerkat (meer8 and older)    | No            | N/A     |
 | Meerkat (meer9)              | Yes           | N/A     |
+| Meerkat (meer10)             | No            | N/A     |
 | Oryx Pro (oryp5 and older)   | No            | No      |
 | Oryx Pro (oryp6 and newer)   | Yes           | Yes     |
 


### PR DESCRIPTION
I found that non-meer9 models were missing from the table. Let me know if this is inaccurate--meer9 seems to be the only open firmware model from what I saw.