### PR TITLE
Re-add CC BY-SA 4.0 license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,1 @@
+This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.


### PR DESCRIPTION
Closes #886. Re-adds the license as it was before (with the HTTP link changed to HTTPS).