### PR TITLE
chore(ci): Bump Nix Shell's Node.js from 18 to 20

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
   pkgs.mkShell {
     nativeBuildInputs = with pkgs; [ 
-       nodejs-18_x 
+       nodejs_20
        nodePackages.npm
        ];
 }


### PR DESCRIPTION
While trying to test https://github.com/system76/docs/pull/1301, I found that a fresh clone of the repo on a system with a fully updated Nix installation (`nix-channel --update`) would no longer work, because Node.js 18 is [end-of-life](https://nodejs.org/en/about/previous-releases) and Nix has removed it from their repo. This updates the package name to use the next LTS release. `npm ci` and `npm start` still work to build the repo after doing this.

This does not affect the live site, only building locally in a Nix shell.