### PR TITLE
fix (CI): Update Nix NPM package name

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,6 @@
   pkgs.mkShell {
     nativeBuildInputs = with pkgs; [ 
        nodejs_20
-       nodePackages.npm
+       pkgs.prefetch-npm-deps
        ];
 }


### PR DESCRIPTION
On a freshly installed system, `nix-shell` was erroring out for me because the old `nodePackages.npm` package has been removed from the Nix package repository (see e.g. https://github.com/nixos/nixpkgs/issues/489959). When I swapped this out with `pkgs.prefetch-npm-deps`, the `nix-shell` build ran successfully, and I was then able to run `npm ci` and `npm start` within the Nix shell as expected.