### PR TITLE
Add docs note to enable in Extensions

### DIFF
--- a/content/pop-shell.md
+++ b/content/pop-shell.md
@@ -55,6 +55,8 @@ make local-install
 sudo dnf install gnome-shell-extension-pop-shell
 ```
 
+After installing, open the Extensions app and enable the toggle for `Pop Shell`.
+
 #### For Arch
 
 <u>Pop Shell</u> is packaged in the AUR, but for the keyboard shortcuts to work, you will need to build it from source like we did above.

--- a/content/pop-shell.md
+++ b/content/pop-shell.md
@@ -55,7 +55,11 @@ make local-install
 sudo dnf install gnome-shell-extension-pop-shell
 ```
 
-After installing, open the Extensions app and enable the toggle for `Pop Shell`.
+After installing, log out and back in (or reboot), then run the following command to enable the extension:
+
+```bash
+gnome-extensions enable pop-shell@system76.com
+```
 
 #### For Arch
 


### PR DESCRIPTION
On Fedora I had to open the Extensions app and enable Pop Shell after installing with dnf